### PR TITLE
Fix Tests and Further Separate Runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ executors:
       - image: circleci/android:api-29-node
     environment:
       - TERM: "dumb"
-      - GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError"'
+      - GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
       - FASTLANE_SKIP_UPDATE_CHECK: true
   mac:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ aliases:
         e:
           name: mac
           xcode: "11.2.0"
-        device: "iPhone 11"
+        device: "iPhone XR"
         ios_version: "12.2"  
     - test-ios-passcode:
         name: "iOS 13 Passcode"
@@ -107,7 +107,7 @@ aliases:
         e:
           name: mac
           xcode: "11.2.0"
-        device: "iPhone 11"
+        device: "iPhone XR"
         ios_version: "12.2" 
 
 
@@ -200,7 +200,7 @@ aliases:
         e:
           name: mac
           xcode: "11.2.0"
-        device: "iPhone 11"
+        device: "iPhone XR"
         ios_version: "12.2"  
         sfdx: true
     - test-ios-passcode:
@@ -216,7 +216,7 @@ aliases:
         e:
           name: mac
           xcode: "11.2.0"
-        device: "iPhone 11"
+        device: "iPhone XR"
         ios_version: "12.2" 
         sfdx: true
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,14 +43,14 @@ aliases:
         name: "iOS 13"
         e:
           name: mac
-          xcode: "11.0.0"
+          xcode: "11.2.0"
         device: "iPhone 11"
-        ios_version: "13.0"    
+        ios_version: "13.2"    
     - test-ios:
         name: iOS 12
         e:
           name: mac
-          xcode: "11.0.0"
+          xcode: "11.2.0"
         device: "iPhone XR"
         ios_version: "12.2"
 
@@ -86,15 +86,15 @@ aliases:
         name: "iOS 13 SFDX"
         e:
           name: mac
-          xcode: "11.0.0"
+          xcode: "11.2.0"
         device: "iPhone 11"
-        ios_version: "13.0"
+        ios_version: "13.2"
         sfdx: true
     - test-ios:
         name: "iOS 12 SFDX"
         e:
           name: mac
-          xcode: "11.0.0"
+          xcode: "11.2.0"
         device: "iPhone XR"
         ios_version: "12.2"
         sfdx: true
@@ -274,7 +274,7 @@ jobs:
             command: cd .circleci && fastlane ios type:native device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx>>" adv_auth:true
             when: always
         - run:
-            name: Test Password
+            name: Test Passcode
             command: cd .circleci && fastlane ios type:native device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx>>" passcode:true
             when: always
         - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,61 +40,75 @@ aliases:
         app_type: "native"
         passcode: true
     - test-ios-native:
-        name: "iOS 13"
+        name: "iOS 13 Native"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone 11"
         ios_version: "13.2"    
     - test-ios-native:
-        name: iOS 12
+        name: "iOS 12 Native"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone XR"
         ios_version: "12.2"
     - test-ios-hybrid:
-        name: "iOS 13"
+        name: "iOS 13 Hybrid"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone 11"
         ios_version: "13.2"    
     - test-ios-hybrid:
-        name: iOS 12
+        name: "iOS 12 Hybrid"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone XR"
         ios_version: "12.2"
     - test-ios-templates:
-        name: "iOS 13"
+        name: "iOS 13 Templates"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone 11"
         ios_version: "13.2"    
     - test-ios-templates:
-        name: iOS 12
+        name: "iOS 12 Templates"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone XR"
         ios_version: "12.2"
     - test-ios-adv-auth:
-        name: "iOS 13"
+        name: "iOS 13 Adv Auth"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"    
+    - test-ios-adv-auth:
+        name: "iOS 12 Adv Auth"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "12.2"  
+    - test-ios-passcode:
+        name: "iOS 13 Passcode"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone 11"
         ios_version: "13.2"    
     - test-ios-passcode:
-        name: iOS 12
+        name: "iOS 12 Passcode"
         e:
           name: mac
           xcode: "11.2.0"
-        device: "iPhone XR"
-        ios_version: "12.2"
+        device: "iPhone 11"
+        ios_version: "12.2" 
 
 
   - &all-jobs-sfdx
@@ -126,23 +140,15 @@ aliases:
         sfdx: true
         e: android-react-native
     - test-ios-native:
-        name: "iOS 13 SFDX"
+        name: "iOS 13 Native SFDX"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone 11"
-        ios_version: "13.2"
+        ios_version: "13.2"    
         sfdx: true
     - test-ios-native:
-        name: "iOS 13"
-        e:
-          name: mac
-          xcode: "11.2.0"
-        device: "iPhone 11"
-        ios_version: "13.2"  
-        sfdx: true  
-    - test-ios-native:
-        name: iOS 12
+        name: "iOS 12 Native SFDX"
         e:
           name: mac
           xcode: "11.2.0"
@@ -150,15 +156,15 @@ aliases:
         ios_version: "12.2"
         sfdx: true
     - test-ios-hybrid:
-        name: "iOS 13"
+        name: "iOS 13 Hybrid SFDX"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone 11"
-        ios_version: "13.2"   
-        sfdx: true 
+        ios_version: "13.2"    
+        sfdx: true
     - test-ios-hybrid:
-        name: iOS 12
+        name: "iOS 12 Hybrid SFDX"
         e:
           name: mac
           xcode: "11.2.0"
@@ -166,15 +172,15 @@ aliases:
         ios_version: "12.2"
         sfdx: true
     - test-ios-templates:
-        name: "iOS 13"
+        name: "iOS 13 Templates SFDX"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone 11"
-        ios_version: "13.2"   
-        sfdx: true 
+        ios_version: "13.2"    
+        sfdx: true
     - test-ios-templates:
-        name: iOS 12
+        name: "iOS 12 Templates SFDX"
         e:
           name: mac
           xcode: "11.2.0"
@@ -182,7 +188,23 @@ aliases:
         ios_version: "12.2"
         sfdx: true
     - test-ios-adv-auth:
-        name: "iOS 13"
+        name: "iOS 13 Adv Auth SFDX"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"    
+        sfdx: true
+    - test-ios-adv-auth:
+        name: "iOS 12 Adv Auth SFDX"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "12.2"  
+        sfdx: true
+    - test-ios-passcode:
+        name: "iOS 13 Passcode SFDX"
         e:
           name: mac
           xcode: "11.2.0"
@@ -190,12 +212,12 @@ aliases:
         ios_version: "13.2"    
         sfdx: true
     - test-ios-passcode:
-        name: iOS 12
+        name: "iOS 12 Passcode SFDX"
         e:
           name: mac
           xcode: "11.2.0"
-        device: "iPhone XR"
-        ios_version: "12.2"
+        device: "iPhone 11"
+        ios_version: "12.2" 
         sfdx: true
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,20 +39,63 @@ aliases:
         name: "Passcode"
         app_type: "native"
         passcode: true
-    - test-ios:
+    - test-ios-native:
         name: "iOS 13"
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone 11"
         ios_version: "13.2"    
-    - test-ios:
+    - test-ios-native:
         name: iOS 12
         e:
           name: mac
           xcode: "11.2.0"
         device: "iPhone XR"
         ios_version: "12.2"
+    - test-ios-hybrid:
+        name: "iOS 13"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"    
+    - test-ios-hybrid:
+        name: iOS 12
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone XR"
+        ios_version: "12.2"
+    - test-ios-templates:
+        name: "iOS 13"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"    
+    - test-ios-templates:
+        name: iOS 12
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone XR"
+        ios_version: "12.2"
+    - test-ios-adv-auth:
+        name: "iOS 13"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"    
+    - test-ios-passcode:
+        name: iOS 12
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone XR"
+        ios_version: "12.2"
+
 
   - &all-jobs-sfdx
     - test-android:
@@ -82,7 +125,7 @@ aliases:
         template: true
         sfdx: true
         e: android-react-native
-    - test-ios:
+    - test-ios-native:
         name: "iOS 13 SFDX"
         e:
           name: mac
@@ -90,8 +133,64 @@ aliases:
         device: "iPhone 11"
         ios_version: "13.2"
         sfdx: true
-    - test-ios:
-        name: "iOS 12 SFDX"
+    - test-ios-native:
+        name: "iOS 13"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"  
+        sfdx: true  
+    - test-ios-native:
+        name: iOS 12
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone XR"
+        ios_version: "12.2"
+        sfdx: true
+    - test-ios-hybrid:
+        name: "iOS 13"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"   
+        sfdx: true 
+    - test-ios-hybrid:
+        name: iOS 12
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone XR"
+        ios_version: "12.2"
+        sfdx: true
+    - test-ios-templates:
+        name: "iOS 13"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"   
+        sfdx: true 
+    - test-ios-templates:
+        name: iOS 12
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone XR"
+        ios_version: "12.2"
+        sfdx: true
+    - test-ios-adv-auth:
+        name: "iOS 13"
+        e:
+          name: mac
+          xcode: "11.2.0"
+        device: "iPhone 11"
+        ios_version: "13.2"    
+        sfdx: true
+    - test-ios-passcode:
+        name: iOS 12
         e:
           name: mac
           xcode: "11.2.0"
@@ -220,7 +319,7 @@ jobs:
           path: firebase/results
           when: always
 
-  test-ios:
+  test-ios-native:
       executor: << parameters.e >>
       parameters:
         ios_version: 
@@ -249,6 +348,28 @@ jobs:
             name: Test Native Swift App
             command: xcrun swift -version && cd .circleci && fastlane ios type:native_swift device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx >>"
             when: always
+
+  test-ios-hybrid:
+      executor: << parameters.e >>
+      parameters:
+        ios_version: 
+            type: string
+        device:
+            type: string
+        sfdx:
+          type: boolean
+          default: false
+        e:
+          type: executor
+      steps:
+        - checkout
+        - run: *setup
+        - when:
+            condition: << parameters.sfdx >>
+            steps:
+              - run:
+                  name: Install SFDX
+                  command: npm install -g sfdx-cli
         - run:
             name: Test Hybrid Local App
             command: cd .circleci && fastlane ios type:hybrid_local device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx >>"
@@ -261,6 +382,28 @@ jobs:
             name: Test React Native App
             command: cd .circleci && fastlane ios type:react_native device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx >>"
             when: always
+
+  test-ios-templates:
+      executor: << parameters.e >>
+      parameters:
+        ios_version: 
+            type: string
+        device:
+            type: string
+        sfdx:
+          type: boolean
+          default: false
+        e:
+          type: executor
+      steps:
+        - checkout
+        - run: *setup
+        - when:
+            condition: << parameters.sfdx >>
+            steps:
+              - run:
+                  name: Install SFDX
+                  command: npm install -g sfdx-cli
         - run:
             name: Test MobileSync Swift Template
             command: cd .circleci && fastlane ios template:https://github.com/forcedotcom/SalesforceMobileSDK-Templates/MobileSyncExplorerSwift\#dev device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx >>"
@@ -269,10 +412,54 @@ jobs:
             name: Test MobileSync React Native Template
             command: cd .circleci && fastlane ios template:https://github.com/forcedotcom/SalesforceMobileSDK-Templates/MobileSyncExplorerReactNative\#dev device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx >>"
             when: always        
+
+  test-ios-adv-auth:
+      executor: << parameters.e >>
+      parameters:
+        ios_version: 
+            type: string
+        device:
+            type: string
+        sfdx:
+          type: boolean
+          default: false
+        e:
+          type: executor
+      steps:
+        - checkout
+        - run: *setup
+        - when:
+            condition: << parameters.sfdx >>
+            steps:
+              - run:
+                  name: Install SFDX
+                  command: npm install -g sfdx-cli
         - run:
             name: Test Advanced Auth
             command: cd .circleci && fastlane ios type:native device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx>>" adv_auth:true
             when: always
+
+  test-ios-passcode:
+      executor: << parameters.e >>
+      parameters:
+        ios_version: 
+            type: string
+        device:
+            type: string
+        sfdx:
+          type: boolean
+          default: false
+        e:
+          type: executor
+      steps:
+        - checkout
+        - run: *setup
+        - when:
+            condition: << parameters.sfdx >>
+            steps:
+              - run:
+                  name: Install SFDX
+                  command: npm install -g sfdx-cli
         - run:
             name: Test Passcode
             command: cd .circleci && fastlane ios type:native device:"<< parameters.device >>" ios:"<< parameters.ios_version >>" sfdx:"<< parameters.sfdx>>" passcode:true

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -232,7 +232,7 @@ def base_ios_test_setup(options)
   if ios
     ios.gsub!('.', '-')
   else
-    ios = '13-0'
+    ios = '13-2'
   end
 
   system("xcrun simctl delete #{$sim_name}") or true

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -170,9 +170,10 @@ def run_android_tests_firebase(test_class, app_info)
   app_info.xcargs.each { |op| optional_vars.concat(",#{op}") } if app_info.xcargs
 
   devices = ''
-  min = test_class.include?('Passcode') ? 24 : 23
+  min = test_class.include?('Passcode') ? 24 : 23  # Passcode field can't be automated for API 23.
   for api_level in min..28 do
-    devices.concat("--device model=NexusLowRes,version=#{api_level},locale=en,orientation=portrait \\")
+    model = (api_level > 25) ? 'Pixel2' : 'NexusLowRes'
+    devices.concat("--device model=#{model},version=#{api_level},locale=en,orientation=portrait \\")
   end
 
   Dir.chdir('./Android/') do

--- a/iOS/Login/LoginTests.swift
+++ b/iOS/Login/LoginTests.swift
@@ -78,6 +78,7 @@ class LoginTests: XCTestCase {
         case .nativeObjC, .nativeSwift:
             XCTAssert(app.navigationBars[sampleAppTitle].waitForExistence(timeout: timeout), appLoadError)
         case .hybridLocal, .hyrbidRemote:
+            sleep(10)
             let titleText = (app.type == .hybridLocal) ? "Contacts" : "Salesforce Mobile SDK Test"
             let title = app.staticTexts[titleText]
             let exists = NSPredicate(format: "exists == 1")
@@ -90,7 +91,10 @@ class LoginTests: XCTestCase {
             let titleElement = app.otherElements.matching(identifier: sampleAppTitle).staticTexts[sampleAppTitle]
             XCTAssert(titleElement.waitForExistence(timeout: timeout), appLoadError)
         case .mobileSyncSwift:
-            let title = app.navigationBars["MobileSync Explorer"].staticTexts["MobileSync Explorer"]
+            // TODO: Remove this when min iOS version is 13
+            let title = ((UIDevice.current.systemVersion as NSString).floatValue >= 13.0) ?
+                app.navigationBars["MobileSync Explorer"].staticTexts["MobileSync Explorer"] :
+                app.navigationBars["MobileSync Explorer"].otherElements["MobileSync Explorer"]
             XCTAssert(title.waitForExistence(timeout: timeout), appLoadError)
             
             // Check MobileSync Works

--- a/iOS/Login/LoginTests.swift
+++ b/iOS/Login/LoginTests.swift
@@ -38,7 +38,7 @@ class LoginTests: XCTestCase {
     private var password = UserUtility().password
     private var appLoadError = "App did not load."
     private var mobileSyncError = "MobileSync did not pull data."
-    private var timeout:double_t = 30
+    private var timeout:double_t = 60
     private let reactNativeUsers = "Automated Process Brandon Page circleci Integration User Security User Chatter Expert Mobile SDK Sample App"
     private let sampleAppTitle = "Mobile SDK Sample App"
     
@@ -83,7 +83,7 @@ class LoginTests: XCTestCase {
             let exists = NSPredicate(format: "exists == 1")
             
             expectation(for: exists, evaluatedWith: title, handler: nil)
-            waitForExpectations(timeout: timeout * 2, handler: nil)
+            waitForExpectations(timeout: timeout, handler: nil)
             XCTAssert(title.exists, appLoadError)
         case .reactNative:
             sleep(30)
@@ -94,7 +94,7 @@ class LoginTests: XCTestCase {
             XCTAssert(title.waitForExistence(timeout: timeout), appLoadError)
             
             // Check MobileSync Works
-            _ = app.tables.cells.firstMatch.waitForExistence(timeout: 3)
+            _ = app.tables.cells.firstMatch.waitForExistence(timeout: timeout)
             XCTAssertGreaterThan(app.tables.cells.count, 0, mobileSyncError)
         case .mobileSyncReact:
             sleep(30)

--- a/iOS/Login/LoginTests.swift
+++ b/iOS/Login/LoginTests.swift
@@ -83,14 +83,14 @@ class LoginTests: XCTestCase {
             let exists = NSPredicate(format: "exists == 1")
             
             expectation(for: exists, evaluatedWith: title, handler: nil)
-            waitForExpectations(timeout: timeout, handler: nil)
+            waitForExpectations(timeout: timeout * 2, handler: nil)
             XCTAssert(title.exists, appLoadError)
         case .reactNative:
             sleep(30)
             let titleElement = app.otherElements.matching(identifier: sampleAppTitle).staticTexts[sampleAppTitle]
             XCTAssert(titleElement.waitForExistence(timeout: timeout), appLoadError)
         case .mobileSyncSwift:
-            let title = app.navigationBars["MobileSync Explorer"].otherElements["MobileSync Explorer"]
+            let title = app.navigationBars["MobileSync Explorer"].staticTexts["MobileSync Explorer"]
             XCTAssert(title.waitForExistence(timeout: timeout), appLoadError)
             
             // Check MobileSync Works

--- a/iOS/PageObjects/LoginPageObjects/AuthorizationPageObject.swift
+++ b/iOS/PageObjects/LoginPageObjects/AuthorizationPageObject.swift
@@ -36,7 +36,7 @@ import XCTest
 
 class AuthorizationPageObject: XCUIScreen {
     let app:XCUIApplication
-    let timeout:double_t = 5
+    let timeout:double_t = 60
     
     init(testApp: XCUIApplication) {
         app = testApp
@@ -52,7 +52,7 @@ class AuthorizationPageObject: XCUIScreen {
     
     private func pressButton(lable: String) {
         let button = app.buttons.element(matching: NSPredicate(format: "label CONTAINS '" + lable + "'"))
-        _ = assert(button.waitForExistence(timeout: timeout * 5))
+        _ = assert(button.waitForExistence(timeout: timeout))
         sleep(2)
         button.tap()
     }

--- a/iOS/PageObjects/LoginPageObjects/LoginPageObject.swift
+++ b/iOS/PageObjects/LoginPageObjects/LoginPageObject.swift
@@ -44,7 +44,7 @@ class LoginPageObject: XCUIScreen {
     
     func setUsername(name: String) -> Void {
         let nameField = app.descendants(matching: .textField).element
-        _ = nameField.waitForExistence(timeout: timeout)
+        _ = nameField.waitForExistence(timeout: timeout * 5)
         nameField.tap()
         sleep(1)
         nameField.typeText(name)

--- a/iOS/PageObjects/LoginPageObjects/LoginPageObject.swift
+++ b/iOS/PageObjects/LoginPageObjects/LoginPageObject.swift
@@ -44,7 +44,7 @@ class LoginPageObject: XCUIScreen {
     
     func setUsername(name: String) -> Void {
         let nameField = app.descendants(matching: .textField).element
-        _ = nameField.waitForExistence(timeout: timeout * 5)
+        _ = nameField.waitForExistence(timeout: timeout * 12)
         nameField.tap()
         sleep(1)
         nameField.typeText(name)

--- a/iOS/PageObjects/PasscodePageObjects/PasscodePageObject.swift
+++ b/iOS/PageObjects/PasscodePageObjects/PasscodePageObject.swift
@@ -43,7 +43,7 @@ class PasscodePageObject: XCUIScreen {
     }
     
     func getNavbarText() -> String {
-        let passcodeTitle = app.navigationBars["Passcode"].otherElements["Passcode"]
+        let passcodeTitle = app.navigationBars["Passcode"].staticTexts["Passcode"]
         _ = passcodeTitle.waitForExistence(timeout: timeout)
         return passcodeTitle.label
     }

--- a/iOS/PageObjects/PasscodePageObjects/PasscodePageObject.swift
+++ b/iOS/PageObjects/PasscodePageObjects/PasscodePageObject.swift
@@ -43,7 +43,9 @@ class PasscodePageObject: XCUIScreen {
     }
     
     func getNavbarText() -> String {
-        let passcodeTitle = app.navigationBars["Passcode"].staticTexts["Passcode"]
+        // TODO: Remove this when min iOS version is 13
+        let passcodeTitle = ((UIDevice.current.systemVersion as NSString).floatValue >= 13.0) ?
+            app.navigationBars["Passcode"].staticTexts["Passcode"] : app.navigationBars["Passcode"].otherElements["Passcode"]
         _ = passcodeTitle.waitForExistence(timeout: timeout)
         return passcodeTitle.label
     }


### PR DESCRIPTION
- Fix most iOS tests failing with Xcode 11.1./11.2.
- Separate native, hybrid, react and templates into individual runs for stability and ease of triaging.
- Increase a few specific timeout to eliminate flapping on iOS 13.  
- Reduce gradle memory allocation for RN Android to get rid of rare oom crash.
- Change Firebase device for API 26-28 to avoid a RN crash.  