### PR TITLE
Add tests for Android and iOS Native Login.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ anchors:
   - &min-ios         "16.4"
   - &device          "iPhone-SE-3rd-generation"
   - &invalid         ""
-  - &MobileSyncExplorerReactNative
-      https://github.com/forcedotcom/SalesforceMobileSDK-Templates/MobileSyncExplorerReactNative\#dev
-  - &MobileSyncSwiftTemplate
-      https://github.com/forcedotcom/SalesforceMobileSDK-Templates/MobileSyncExplorerSwift\#dev
 
 version: 2.1
 jobs:
@@ -277,13 +273,34 @@ workflows:
             branches:
               only:
                 - /pull.*/
+      - test-android:
+          name: Android Native Login 
+          context: Mobile SDK UI Tests
+          matrix:
+            parameters: 
+              app_type: ["AndroidNativeLoginTemplate"]
+              template: [true]
+          filters:
+            branches:
+              only:
+                - /pull.*/
       - test-ios:
-          name: iOS << matrix.ios >> << matrix.app_type >> 
+          name: iOS << matrix.app_type >> 
           context: Mobile SDK UI Tests
           matrix:
             parameters: 
               app_type: ["native", "native_swift", "hybrid_local", "hybrid_remote", "react_native"]
-              ios: [*min-ios, *latest-ios]
+          filters:
+            branches:
+              only:
+                - /pull.*/
+      - test-ios:
+          name: iOS Native Login Template
+          context: Mobile SDK UI Tests
+          matrix: 
+            parameters: 
+              app_type: ["iOSNativeLoginTemplate"]
+              template: [true]
           filters:
             branches:
               only:
@@ -323,9 +340,16 @@ workflows:
           context: Mobile SDK UI Tests
           matrix:
             parameters: 
-              app_type: [*MobileSyncExplorerReactNative]
+              app_type: ["MobileSyncExplorerReactNative"]
               template: [true]
               resource_size: ["medium+"]
+      - test-android:
+          name: Android Native Login 
+          context: Mobile SDK UI Tests
+          matrix:
+            parameters: 
+              app_type: ["AndroidNativeLoginTemplate"]
+              template: [true]
       - test-android:
           name: Android Advanced Auth
           context: Mobile SDK UI Tests
@@ -355,7 +379,7 @@ workflows:
           context: Mobile SDK UI Tests
           matrix: 
             parameters: 
-              app_type: [*MobileSyncExplorerReactNative, *MobileSyncSwiftTemplate]
+              app_type: ["MobileSyncExplorerReactNative", "MobileSyncExplorerSwift", "iOSNativeLoginTemplate"]
               ios: [*min-ios, *latest-ios]
               template: [true]
       - test-ios:
@@ -402,7 +426,7 @@ workflows:
           context: Mobile SDK UI Tests
           matrix: 
             parameters: 
-              app_type: [*MobileSyncExplorerReactNative, *MobileSyncSwiftTemplate]
+              app_type: ["MobileSyncExplorerReactNative", "MobileSyncExplorerSwift"]
               xcode: [<< pipeline.parameters.xcode >>]
               ios: [<< pipeline.parameters.ios >>]
               device: [<< pipeline.parameters.device >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,7 @@ workflows:
             parameters: 
               app_type: ["AndroidNativeLoginTemplate"]
               template: [true]
+              resource_size: ["medium+"]
           filters:
             branches:
               only:

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -8,6 +8,9 @@ $default_consumer_key = '3MVG98dostKihXN53TYStBIiS8FC2a3tE3XhGId0hQ37iQjF0xe4fxM
 $default_redirect_uri = 'testsfdc:///mobilesdk/detect/oauth/done'
 $adv_auth_consumer_key = '3MVG9CEn_O3jvv0wTqRT0Le6tmyfUanAsJ6rWLQniOaec1Ks6YBBYFaJSfMREVJdPeRxTneqgoSxdswYvb9vP'
 $adv_auth_redirect_uri = 'com.mobilesdk.advauth:///oauth/success'
+$native_login_consumer_key = '3MVG9CEn_O3jvv0wTqRT0Le6tmzX.EQ9ZvtHL1TG3gHFV.4IvKZyXw5SgdiVPi61mXrpu40mCOhKevEfYNMOm'
+$native_login_redirect_uri = 'https://msdk-enhanced-dev-ed.my.site.com/services/oauth2/echo'
+$native_login_url = 'https://msdk-enhanced-dev-ed.my.site.com/headless'
 $android_login_activity = '<activity android:name="com.salesforce.androidsdk.ui.LoginActivity'
 
 #
@@ -30,13 +33,26 @@ App_Info = Struct.new(:os, :app_name, :app_path, :package_name, :xcargs, :sfdx)
 lane :ios do |options|
   app_info = base_ios_test_setup(options)
   install_ios_app(app_info)
-  run_ios_tests('TestLogin', app_info.package_name, app_info.xcargs)
+
+  test_class =  if is_native_login(app_info.app_name)
+                  'TestNativeLogin'
+                else
+                  'TestLogin'
+                end
+
+  run_ios_tests(test_class, app_info.package_name, app_info.xcargs)
 end
 
 lane :android do |options|
   Dir.chdir('../../')
   app_info = base_android_test_setup(options)
-  test_class = 'com.salesforce.mobilesdk.mobilesdkuitest.login.LoginTests'
+  
+  test_class = 'com.salesforce.mobilesdk.mobilesdkuitest.login.'
+  if is_native_login(app_info.app_name)
+    test_class.concat('NativeLoginTests')
+  else
+    test_class.concat('LoginTests')
+  end
 
   if $is_ci
     run_android_tests_firebase(test_class, app_info)
@@ -95,19 +111,25 @@ end
 #
 # Generic Reusable Helper Functions
 #
-def get_password()
-  if ENV.has_key? 'CI_USER_PASSWORD'
-    return ENV['CI_USER_PASSWORD']
+def get_password(native_login = false)
+  if native_login 
+    if ENV.has_key? 'CI_USER_NATIVE_PASSWORD'
+      return ENV['CI_USER_NATIVE_PASSWORD']
+    end
   else
-    # Crash if not set for CI
-    UI.crash!('Error: Password should be set in CircleCI Environment Variables.') if $is_ci
-
-    # Let user recover for local run
-    UI.important 'Error: CI User Password not set!!!'
-    UI.important 'For future use please execute: export CI_USER_PASSWORD=<password>'
-    UI.important 'CI User Password can be found here: https://salesforce.quip.com/RmK0A8aSX3Cc'
-    return prompt(text: 'To recover now, enter the password for CI User:')
+    if ENV.has_key? 'CI_USER_PASSWORD'
+      return ENV['CI_USER_PASSWORD']
+    end
   end
+  
+  # Crash if not set for CI
+  UI.crash!('Error: Password should be set in CircleCI Environment Variables.') if $is_ci
+
+  # Let user recover for local run
+  UI.important 'Error: CI User Password not set!!!'
+  UI.important 'For future use please execute: export CI_USER_PASSWORD=<password>'
+  UI.important 'CI User Password can be found here: https://salesforce.quip.com/RmK0A8aSX3Cc'
+  return prompt(text: 'To recover now, enter the password for CI User:')
 end
 
 # Either type or template needs to be set.
@@ -126,7 +148,13 @@ def generate_app(os, type = nil, template = nil, sfdx = nil)
     end
   else
     UI.header 'Generating App from Template'
-    generate_command.concat("  --templaterepouri=#{template}")
+    templateUrl = if template.start_with?('https')
+                    template
+                  else
+                    "https://github.com/forcedotcom/SalesforceMobileSDK-Templates/#{template}\#dev"
+                  end
+
+    generate_command.concat("  --templaterepouri=#{templateUrl}")
   end
 
   if sfdx
@@ -146,7 +174,6 @@ end
 #
 def base_android_test_setup(options)
   $is_ci = true if options[:firebase] 
-  $password = get_password
   run_type = options[:type]
   template = options[:template]
   UI.user_error!('Please specify run type.') unless(run_type or template)
@@ -162,8 +189,11 @@ def base_android_test_setup(options)
   end
 
   app_type = template ? templateName : run_type
-  app_name = 'android'.concat(app_type).gsub('_', '')
+  app_name = app_type.gsub('_', '')
+  app_name = 'android' + app_name unless template
+  app_name.delete_suffix!('template') if template
   package_name = "com.salesforce.#{app_name}"
+  $password = get_password(is_native_login(app_name))
 
   generate_app('android', run_type, template, sfdx) unless rerun
   app_path = Dir.glob("tmp*").sort.first.concat("/#{app_name}/")
@@ -197,7 +227,7 @@ def base_android_test_setup(options)
     end
   end
 
-  app_info = App_Info.new('android', app_type, app_path, package_name, args, sfdx)
+  app_info = App_Info.new('android', app_name, app_path, package_name, args, sfdx)
   if adv_auth
     setup_adv_auth(app_info)
   end
@@ -205,6 +235,10 @@ def base_android_test_setup(options)
   if complexHybrid
     args.push("complexHybrid=#{complexHybrid}")
     UI.important('args: ' + args.inspect())
+  end
+
+  if is_native_login(app_name) 
+    setup_native_login(app_info)
   end
   
   return app_info
@@ -257,8 +291,7 @@ def run_android_tests_firebase(test_class, app_info)
       if adv_auth && api_level.between?(26, 28)
         next
       else
-        model = api_level < 26 ? "Nexus9" : "MediumPhone.arm"
-        devices.concat("--device model=#{model},version=#{api_level},locale=en,orientation=portrait \\")
+        devices.concat("--device model=MediumPhone.arm,version=#{api_level},locale=en,orientation=portrait \\")
       end
     end
   end
@@ -287,7 +320,6 @@ end
 # iOS Helper Functions
 #
 def base_ios_test_setup(options)
-  $password = get_password
   run_type = options[:type]
   template = options[:template]
   UI.user_error!('Please specify run type.') unless(run_type or template)
@@ -311,6 +343,7 @@ def base_ios_test_setup(options)
   end
 
   app_name = 'ios'.concat(template ? templateName : "#{run_type}").gsub('_', '')
+  $password = get_password(is_native_login(app_name))
   system("rm -rf ../../test_output/#{app_name}")
   bundle_name = is_hybird(app_name) ? "com.salesforce.#{app_name}" : "com.salesforce.#{app_name.gsub('_', '-')}"
   start_emulator(device, ios)
@@ -339,6 +372,10 @@ def base_ios_test_setup(options)
 
     if complexHybrid
       xcargs.push("COMPLEX_HYBRID=#{complexHybrid}")
+    end
+
+    if is_native_login(app_name) 
+      setup_native_login(app_info, false)
     end
 
     return app_info
@@ -569,6 +606,26 @@ def setup_complex_hybrid(complexHybrid, app_path)
   end }
 end
 
+def setup_native_login(app_info, is_android = true)
+  if is_android
+    source_path = app_info.app_path + 'app/src/main/java/com/salesforce/androidnativelogin/MainApplication.kt'
+    modify_source(source_path, "val clientId = \"your-client-id\"", "val clientId = \"#{$native_login_consumer_key}\"")
+    modify_source(source_path, "val redirectUri = \"your-redirect-uri\"", "val redirectUri = \"#{$native_login_redirect_uri}\"")
+    modify_source(source_path, "val loginUrl = \"your-community-url\"", "val loginUrl = \"#{$native_login_url}\"")
+  
+    UI.important 'Rebuilding with modified source files'
+    Dir.chdir(app_info. app_path) do
+      result = silence_output { system("./gradlew assemble --no-daemon") }
+      UI.build_failure!('Failed to rebuild with modified source files.') unless result
+    end
+  else
+    source_path = app_info.app_path + app_info.app_name + '/SceneDelegate.swift'
+    modify_source(source_path, "let clientId = \"your-client-id\"", "let clientId = \"#{$native_login_consumer_key}\"")
+    modify_source(source_path, "let redirectUri = \"your-redirect-uri\"", "let redirectUri = \"#{$native_login_redirect_uri}\"")
+    modify_source(source_path, "let loginUrl = \"your-community-url\"", "let loginUrl = \"#{$native_login_url}\"")
+  end
+end
+
 # Generic Helpers
 def is_hybird(app_name)
   app_name.downcase.include?('hybrid')
@@ -576,4 +633,8 @@ end
 
 def is_react(app_name)
   app_name.downcase.include?('react')
+end
+
+def is_native_login(app_name)
+  app_name.downcase == 'androidnativelogin' or app_name.downcase == 'iosnativelogin'
 end

--- a/Android/app/src/androidTest/java/PageObjects/TestAppPageObjects/NativeAppPageObject.kt
+++ b/Android/app/src/androidTest/java/PageObjects/TestAppPageObjects/NativeAppPageObject.kt
@@ -37,7 +37,7 @@ class NativeAppPageObject(private val app: TestApplication) : BasePageObject() {
 
     fun assertAppLoads() {
         // This sleep prevents the test from reading the titleBar of the login page 
-        Thread.sleep(timeout / 5)
+        Thread.sleep(timeout)
         val titleBar = device.findObject(UiSelector().className(textViewClass).index(0))
         titleBar.waitForExists(timeout * 5)
         Assert.assertEquals("App did not successfully login.", app.name, titleBar.text)

--- a/Android/app/src/androidTest/java/TestUtility/UserUtility.kt
+++ b/Android/app/src/androidTest/java/TestUtility/UserUtility.kt
@@ -32,7 +32,10 @@ import androidx.test.platform.app.InstrumentationRegistry
  * Created by bpage on 2/28/18.
  */
 class UserUtility {
-    private var _username = InstrumentationRegistry.getArguments().getString("username")
-    var username: String = if(_username == null ) "circleci@mobilesdk.com" else _username as String
-    var password: String = InstrumentationRegistry.getArguments().getString("password") as String
+    companion object {
+        private var _username = InstrumentationRegistry.getArguments().getString("username")
+        var username: String = if (_username == null) "circleci@mobilesdk.com" else _username as String
+        var password: String = InstrumentationRegistry.getArguments().getString("password") as String
+        var nativeLoginUsername: String = if (_username == null) "bpage2@salesforce.com" else _username as String
+    }
 }

--- a/Android/app/src/androidTest/java/com/salesforce/mobilesdk/mobilesdkuitest/login/LoginTests.kt
+++ b/Android/app/src/androidTest/java/com/salesforce/mobilesdk/mobilesdkuitest/login/LoginTests.kt
@@ -42,9 +42,6 @@ import pageobjects.testapppageobjects.*
 @RunWith(AndroidJUnit4::class)
 class LoginTests {
     private var app = TestApplication()
-    private var userUtil = UserUtility()
-    private var username = userUtil.username
-    private var password = userUtil.password
 
     @Before
     fun setupTestApp() {
@@ -56,8 +53,8 @@ class LoginTests {
         Assert.assertEquals("Wrong browser is used for login.", app.advAuth, ChromePageObject().isAdvAuth())
 
         val loginPage = LoginPageObject()
-        loginPage.setUsername(username)
-        loginPage.setPassword(password)
+        loginPage.setUsername(UserUtility.username)
+        loginPage.setPassword(UserUtility.password)
         loginPage.tapLogin()
         AuthorizationPageObject().tapAllowIfPresent()
 

--- a/Android/app/src/androidTest/java/com/salesforce/mobilesdk/mobilesdkuitest/login/NativeLoginTests.kt
+++ b/Android/app/src/androidTest/java/com/salesforce/mobilesdk/mobilesdkuitest/login/NativeLoginTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-present, salesforce.com, inc.
+ * Copyright (c) 2024-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -24,24 +24,33 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-//
-//  UserUtility.swift
-//  SalesforceMobileSDK-UITest
-//
-//  Created by Brandon Page on 3/29/18.
-//
+package com.salesforce.mobilesdk.mobilesdkuitest.login
 
-import Foundation
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import pageobjects.loginpageobjects.LoginPageObject
+import pageobjects.testapppageobjects.NativeAppPageObject
+import pageobjects.testapppageobjects.TestApplication
+import testutility.UserUtility
 
-class UserUtility {
-    var username = ""
-    var nativeLoginUsername = ""
-    var password = ""
+@RunWith(AndroidJUnit4::class)
+class NativeLoginTests {
+    private var app = TestApplication()
 
-    init() {
-        let envUsername = ProcessInfo.processInfo.environment["USERNAME"] ?? ""
-        username = envUsername.isEmpty ? "circleci@mobilesdk.com" : envUsername
-        nativeLoginUsername = envUsername.isEmpty ? "bpage2@salesforce.com" : envUsername
-        password = ProcessInfo.processInfo.environment["PASSWORD"]!
+    @Before
+    fun setupTestApp() {
+        app.launch()
+    }
+
+    @Test
+    fun testLogin() {
+        val loginPage = LoginPageObject()
+        loginPage.setUsername(UserUtility.nativeLoginUsername)
+        loginPage.setPassword(UserUtility.password)
+        loginPage.tapLogin()
+
+        NativeAppPageObject(app).assertAppLoads()
     }
 }

--- a/iOS/PageObjects/LoginPageObjects/NativeLoginPageObject.swift
+++ b/iOS/PageObjects/LoginPageObjects/NativeLoginPageObject.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-present, salesforce.com, inc.
+ * Copyright (c) 2024-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -25,23 +25,21 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 //
-//  UserUtility.swift
+//  NativeLoginPageObject.swift
 //  SalesforceMobileSDK-UITest
 //
-//  Created by Brandon Page on 3/29/18.
+//  Created by Brandon Page on 4/20/24.
 //
 
 import Foundation
+import XCTest
 
-class UserUtility {
-    var username = ""
-    var nativeLoginUsername = ""
-    var password = ""
-
-    init() {
-        let envUsername = ProcessInfo.processInfo.environment["USERNAME"] ?? ""
-        username = envUsername.isEmpty ? "circleci@mobilesdk.com" : envUsername
-        nativeLoginUsername = envUsername.isEmpty ? "bpage2@salesforce.com" : envUsername
-        password = ProcessInfo.processInfo.environment["PASSWORD"]!
+class NativeLoginPageObject: LoginPageObject {
+    
+    override func tapLogin() -> Void {
+        hideKeyboard()
+        let loginButton = app.buttons["Log In"]
+        _ = loginButton.waitForExistence(timeout: timeout)
+        loginButton.tap()
     }
 }

--- a/iOS/PageObjects/TestApplication.swift
+++ b/iOS/PageObjects/TestApplication.swift
@@ -55,7 +55,7 @@ class TestApplication: XCUIApplication {
         switch bundleString {
         case "com.salesforce.iosnative":
             type = .nativeObjC
-        case "com.salesforce.iosnativeswift":
+        case "com.salesforce.iosnativeswift", "com.salesforce.iosnativelogin":
             type = .nativeSwift
         case "com.salesforce.ioshybridlocal":
             type = .hybridLocal

--- a/iOS/SalesforceMobileSDK-UITest.xcodeproj/project.pbxproj
+++ b/iOS/SalesforceMobileSDK-UITest.xcodeproj/project.pbxproj
@@ -10,7 +10,9 @@
 		A3045A28203E241B0028F46F /* TestApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3045A27203E241B0028F46F /* TestApplication.swift */; };
 		A3045A2A203E26AD0028F46F /* LoginPageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3045A29203E26AD0028F46F /* LoginPageObject.swift */; };
 		A3045A2C203E2F420028F46F /* AuthorizationPageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3045A2B203E2F420028F46F /* AuthorizationPageObject.swift */; };
+		A381912D2BD496B500A93F6A /* NativeLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A381912C2BD496B500A93F6A /* NativeLoginTests.swift */; };
 		A39442FB2024D440006022F8 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39442FA2024D440006022F8 /* LoginTests.swift */; };
+		A396F6662BD4BEDD007BD55A /* NativeLoginPageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A396F6652BD4BEDD007BD55A /* NativeLoginPageObject.swift */; };
 		A3DD05AE237E1F4D006C2125 /* BaseSDKTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DD05AD237E1F4D006C2125 /* BaseSDKTest.swift */; };
 		A3F06182206DC48100ADA1DD /* UserUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F06181206DC48100ADA1DD /* UserUtility.swift */; };
 /* End PBXBuildFile section */
@@ -20,7 +22,9 @@
 		A3045A29203E26AD0028F46F /* LoginPageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPageObject.swift; sourceTree = "<group>"; };
 		A3045A2B203E2F420028F46F /* AuthorizationPageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationPageObject.swift; sourceTree = "<group>"; };
 		A34A749F20239B4E00846B32 /* SalesforceMobileSDK-UITest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SalesforceMobileSDK-UITest.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A381912C2BD496B500A93F6A /* NativeLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeLoginTests.swift; sourceTree = "<group>"; };
 		A39442FA2024D440006022F8 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
+		A396F6652BD4BEDD007BD55A /* NativeLoginPageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeLoginPageObject.swift; sourceTree = "<group>"; };
 		A39F9D4B2024CD5100251414 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A3DD05AD237E1F4D006C2125 /* BaseSDKTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseSDKTest.swift; sourceTree = "<group>"; };
 		A3F06181206DC48100ADA1DD /* UserUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUtility.swift; sourceTree = "<group>"; };
@@ -70,6 +74,7 @@
 			children = (
 				A39442FA2024D440006022F8 /* LoginTests.swift */,
 				A3DD05AD237E1F4D006C2125 /* BaseSDKTest.swift */,
+				A381912C2BD496B500A93F6A /* NativeLoginTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -87,6 +92,7 @@
 			children = (
 				A3045A2B203E2F420028F46F /* AuthorizationPageObject.swift */,
 				A3045A29203E26AD0028F46F /* LoginPageObject.swift */,
+				A396F6652BD4BEDD007BD55A /* NativeLoginPageObject.swift */,
 			);
 			path = LoginPageObjects;
 			sourceTree = "<group>";
@@ -160,6 +166,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				A3045A28203E241B0028F46F /* TestApplication.swift in Sources */,
+				A381912D2BD496B500A93F6A /* NativeLoginTests.swift in Sources */,
+				A396F6662BD4BEDD007BD55A /* NativeLoginPageObject.swift in Sources */,
 				A3DD05AE237E1F4D006C2125 /* BaseSDKTest.swift in Sources */,
 				A3045A2C203E2F420028F46F /* AuthorizationPageObject.swift in Sources */,
 				A3F06182206DC48100ADA1DD /* UserUtility.swift in Sources */,

--- a/iOS/SalesforceMobileSDK-UITest.xcodeproj/xcshareddata/xcschemes/TestLogin.xcscheme
+++ b/iOS/SalesforceMobileSDK-UITest.xcodeproj/xcshareddata/xcschemes/TestLogin.xcscheme
@@ -82,6 +82,12 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "BaseSDKTest">
+               </Test>
+               <Test
+                  Identifier = "NativeLoginTests">
+               </Test>
+               <Test
                   Identifier = "PasscodeTests">
                </Test>
             </SkippedTests>

--- a/iOS/SalesforceMobileSDK-UITest.xcodeproj/xcshareddata/xcschemes/TestNativeLogin.xcscheme
+++ b/iOS/SalesforceMobileSDK-UITest.xcodeproj/xcshareddata/xcschemes/TestNativeLogin.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -36,10 +37,21 @@
             ReferencedContainer = "container:SalesforceMobileSDK-UITest.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = ""
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "USERNAME"
             value = "$(USERNAME)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "COMPLEX_HYBRID"
+            value = "${COMPLEX_HYBRID}"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -57,11 +69,6 @@
             value = "$(ADV_AUTH)"
             isEnabled = "YES">
          </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "COMPLEX_HYBRID"
-            value = "${COMPLEX_HYBRID}"
-            isEnabled = "YES">
-         </EnvironmentVariable>
       </EnvironmentVariables>
       <Testables>
          <TestableReference
@@ -75,7 +82,13 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "BaseSDKTest">
+               </Test>
+               <Test
                   Identifier = "LoginTests">
+               </Test>
+               <Test
+                  Identifier = "PasscodeTests">
                </Test>
             </SkippedTests>
          </TestableReference>
@@ -85,7 +98,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "0"
+      launchStyle = "1"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/iOS/Tests/BaseSDKTest.swift
+++ b/iOS/Tests/BaseSDKTest.swift
@@ -36,6 +36,7 @@ import XCTest
 
 class BaseSDKTest: XCTestCase {
     var username = UserUtility().username
+    var nativeLoginUsername = UserUtility().nativeLoginUsername
     var password = UserUtility().password
     var timeout:double_t = 60
     private var appLoadError = "App did not load."

--- a/iOS/Tests/NativeLoginTests.swift
+++ b/iOS/Tests/NativeLoginTests.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-present, salesforce.com, inc.
+ * Copyright (c) 2024-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -25,23 +25,26 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 //
-//  UserUtility.swift
+//  NativeLoginTests.swift
 //  SalesforceMobileSDK-UITest
 //
-//  Created by Brandon Page on 3/29/18.
+//  Created by Brandon Page on 4/20/24.
 //
 
-import Foundation
+import XCTest
 
-class UserUtility {
-    var username = ""
-    var nativeLoginUsername = ""
-    var password = ""
-
-    init() {
-        let envUsername = ProcessInfo.processInfo.environment["USERNAME"] ?? ""
-        username = envUsername.isEmpty ? "circleci@mobilesdk.com" : envUsername
-        nativeLoginUsername = envUsername.isEmpty ? "bpage2@salesforce.com" : envUsername
-        password = ProcessInfo.processInfo.environment["PASSWORD"]!
+class NativeLoginTests: BaseSDKTest {
+    
+    func testLogin() {
+        let app = TestApplication()
+        let loginPage = NativeLoginPageObject(testApp: app)
+        app.launch()
+        
+        loginPage.setUsername(name: nativeLoginUsername)
+        loginPage.setPassword(password: password)
+        loginPage.tapLogin()
+        
+        // Assert App loads
+        assertAppLoads(app: app)
     }
 }


### PR DESCRIPTION
Depends on https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/405

Updates:
-  The `template` param now accepts _either_ the template name (e.g. "AndroidNativeLoginTemplate") or the old way of supplying the full template URL that the packager accepts (still useful for running against a non-dev version or a template in a fork).
- Added Native Login Setup func that replaces out dummy strings with the real connected app/community details to the app will compile.  
- Added a new `NativeLoginTests`/`TestNativeLogin` classes (and iOS scheme).  
- Setup a second, native login specific, set of credentials for login. 
- Native Login templates run on PR (and full builds).  Reduced the total number of skews that run on PR.