### PR TITLE
Remove native appType from CI test matrices

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -3,7 +3,7 @@ on:
     inputs:
       app:
         type: string
-        default: native
+        default: native_kotlin
       sfdx:
         type: boolean
         default: false

--- a/.github/workflows/ios-reusable-workflow.yaml
+++ b/.github/workflows/ios-reusable-workflow.yaml
@@ -3,7 +3,7 @@ on:
     inputs:
       app:
         type: string
-        default: native
+        default: native_swift
       sfdx:
         type: boolean
         default: false

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app:  [native, native_kotlin, hybrid_local, hybrid_remote, react_native, MobileSyncExplorerReactNative, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
+        app:  [native_kotlin, hybrid_local, hybrid_remote, react_native, MobileSyncExplorerReactNative, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
     uses: ./.github/workflows/android-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app:  [native, hybrid_local, react_native]
+        app:  [hybrid_local, react_native]
     uses: ./.github/workflows/android-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app:  [native, native_swift, hybrid_local, hybrid_remote, react_native, MobileSyncExplorerReactNative, MobileSyncExplorerSwift, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
+        app:  [native_swift, hybrid_local, hybrid_remote, react_native, MobileSyncExplorerReactNative, MobileSyncExplorerSwift, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
     uses: ./.github/workflows/ios-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app:  [native, native_swift, hybrid_local, hybrid_remote, react_native, MobileSyncExplorerReactNative, MobileSyncExplorerSwift, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
+        app:  [native_swift, hybrid_local, hybrid_remote, react_native, MobileSyncExplorerReactNative, MobileSyncExplorerSwift, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
     uses: ./.github/workflows/ios-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [native, hybrid_local, react_native]
+        app: [hybrid_local, react_native]
     uses: ./.github/workflows/ios-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app:  [hybrid_local, react_native]
+        app:  [native_kotlin, hybrid_local, react_native]
     uses: ./.github/workflows/android-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [hybrid_local, react_native]
+        app: [native_swift, hybrid_local, react_native]
     uses: ./.github/workflows/ios-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [native, hybrid_local, react_native] 
+        app: [hybrid_local, react_native] 
     uses: ./.github/workflows/ios-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [native, hybrid_local, react_native]
+        app: [hybrid_local, react_native]
     uses: ./.github/workflows/android-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [hybrid_local, react_native] 
+        app: [native_swift, hybrid_local, react_native] 
     uses: ./.github/workflows/ios-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [hybrid_local, react_native]
+        app: [native_kotlin, hybrid_local, react_native]
     uses: ./.github/workflows/android-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}


### PR DESCRIPTION
## Summary

Remove 'native' appType from GitHub Actions workflow test matrices after removing iOSNativeTemplate and AndroidNativeTemplate from the Templates repository.

## Changes

- nightly.yaml: Removed 'native' from all 5 matrix definitions
  - android-base
  - android-sfdx
  - ios-base-legacy
  - ios-base
  - ios-sfdx
- pr.yaml: Removed 'native' from both matrix definitions
  - ios-pr
  - android-pr
- ios-reusable-workflow.yaml: Changed default app from 'native' to 'native_swift'
- android-reusable-workflow.yaml: Changed default app from 'native' to 'native_kotlin'

## Impact

CI workflows will now only test modern template variants:
- native_swift for iOS (Swift)
- native_kotlin for Android (Kotlin)

The legacy Java (Android) and Objective-C (iOS) templates are no longer tested.

## Related PRs

- SalesforceMobileSDK-Templates PR #494 - Remove template files
- SalesforceMobileSDK-Package PR #327 - Remove appType from CLI tools