### PR TITLE
Add sdkVersion option to specify version of the generated app to be tested.

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -7,6 +7,10 @@ on:
       sfdx:
         type: boolean
         default: false
+      sdkVersion:
+        type: string
+        default: ""
+        description: "SDK branch/tag to generate and test (leave empty for dev)"
       is_pr:
         type: boolean
         default: false
@@ -56,10 +60,15 @@ jobs:
           SFDX=""
 
           if ${{ inputs.sfdx }} ; then
-            TYPE="--sf"
+            SFDX="--sf"
           fi
 
-          ./test android ${{ inputs.app }} ${SFDX}
+          SDK_VERSION=""
+          if [ -n "${{ inputs.sdkVersion }}" ]; then
+            SDK_VERSION="--sdkVersion=${{ inputs.sdkVersion }}"
+          fi
+
+          ./test android ${{ inputs.app }} ${SFDX} ${SDK_VERSION}
       - name: Copy Test Results
         continue-on-error: true
         if: success() || failure()

--- a/.github/workflows/ios-reusable-workflow.yaml
+++ b/.github/workflows/ios-reusable-workflow.yaml
@@ -21,6 +21,10 @@ on:
         type: string
         default: ""
         description: "SDK version/branch/tag to upgrade FROM (leave empty for normal test)"
+      sdkVersion:
+        type: string
+        default: ""
+        description: "SDK branch/tag to generate and test (leave empty for dev)"
 
 jobs:
   test-ios:
@@ -65,7 +69,12 @@ jobs:
             UPGRADE="--upgrade=${{ inputs.upgradeFrom }}"
           fi
 
-          ./test ios ${{ inputs.app }} --ios "${{ inputs.ios }}" ${SFDX} ${UPGRADE}
+          SDK_VERSION=""
+          if [ -n "${{ inputs.sdkVersion }}" ]; then
+            SDK_VERSION="--sdkVersion=${{ inputs.sdkVersion }}"
+          fi
+
+          ./test ios ${{ inputs.app }} --ios "${{ inputs.ios }}" ${SFDX} ${UPGRADE} ${SDK_VERSION}
       - name: Convert Test Results to JUnit XML
         if: success() || failure()
         run: |

--- a/.github/workflows/version-test.yaml
+++ b/.github/workflows/version-test.yaml
@@ -1,0 +1,50 @@
+name: Version Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      sdkVersion:
+        description: "SDK branch or tag to test (e.g. 'master' or 'v13.2.0')"
+        required: true
+        type: string
+
+jobs:
+  android:
+    name: ${{ matrix.app }} Android
+    strategy:
+      fail-fast: false
+      matrix:
+        app:  [native_kotlin, MobileSyncExplorerKotlin, hybrid_local, hybrid_remote, MobileSyncExplorerReactNative, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
+    uses: ./.github/workflows/android-reusable-workflow.yaml
+    with:
+      app: ${{ matrix.app }}
+      sdkVersion: ${{ inputs.sdkVersion }}
+    secrets: inherit
+
+  ios-legacy:
+    name: ${{ matrix.app }} iOS 18
+    strategy:
+      fail-fast: false
+      matrix:
+        app:  [native_swift, MobileSyncExplorerSwift, hybrid_local, hybrid_remote, MobileSyncExplorerReactNative, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
+        ios: ["17", "18"]
+    uses: ./.github/workflows/ios-reusable-workflow.yaml
+    with:
+      app: ${{ matrix.app }}
+      ios: ${{ matrix.ios }}
+      runner: macos-15
+      sdkVersion: ${{ inputs.sdkVersion }}
+    secrets: inherit
+
+  ios:
+    name: ${{ matrix.app }} iOS 26
+    strategy:
+      fail-fast: false
+      matrix:
+        app:  [native_swift, MobileSyncExplorerSwift, hybrid_local, hybrid_remote, MobileSyncExplorerReactNative, complex_hybrid_accounteditor, complex_hybrid_mobilesyncexplorer]
+    uses: ./.github/workflows/ios-reusable-workflow.yaml
+    with:
+      app: ${{ matrix.app }}
+      ios: "26"
+      sdkVersion: ${{ inputs.sdkVersion }}
+    secrets: inherit

--- a/TestOrchestrator/src/main/kotlin/AppGenerator.kt
+++ b/TestOrchestrator/src/main/kotlin/AppGenerator.kt
@@ -35,6 +35,16 @@ import kotlin.io.path.Path
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.pathString
 
+// Maps AppType.scriptValue to its template path name in SalesforceMobileSDK-Templates.
+// Mirrors appTypesToPath from SalesforceMobileSDK-Package/shared/constants.js.
+private val APP_TYPE_TO_TEMPLATE = mapOf(
+    "native_swift" to "iOSNativeSwiftTemplate",
+    "native_kotlin" to "AndroidNativeKotlinTemplate",
+    "hybrid_local" to "HybridLocalTemplate",
+    "hybrid_remote" to "HybridRemoteTemplate",
+    "react_native" to "ReactNativeTemplate",
+)
+
 fun generateApp(
     appSource: AppSource,
     useSF: Boolean,
@@ -50,9 +60,19 @@ fun generateApp(
 
     when(appSource) {
         is AppSource.ByType -> {
-            verbosePrinter?.invoke("Generating ${appSource.type.scriptValue} App")
             val type = if (appSource.isComplexHybrid) "hybrid_local" else appSource.type.scriptValue
-            generationCommand.add("--appType=$type")
+
+            if (org != FORCE_DOT_COM_ORG) {
+                // Fork: use --templaterepouri pointing at the fork's templates
+                val templatePath = APP_TYPE_TO_TEMPLATE[type]
+                    ?: throw Exception("No template mapping for app type '$type'.")
+                val templateUrl = "https://github.com/$org/SalesforceMobileSDK-Templates/$templatePath#$packagerVersion"
+                verbosePrinter?.invoke("Generating ${appSource.type.scriptValue} App ($org/$packagerVersion)")
+                generationCommand.add("--templaterepouri=$templateUrl")
+            } else {
+                verbosePrinter?.invoke("Generating ${appSource.type.scriptValue} App")
+                generationCommand.add("--appType=$type")
+            }
 
             if (appSource.isHybrid) {
                 generationCommand.add("--no-plugin-update")
@@ -63,8 +83,6 @@ fun generateApp(
                 verbosePrinter?.invoke("Generating Template App")
                 appSource.template
             } else if (packagerVersion != null) {
-                // Old packager for upgrade testing: use the version tag so the
-                // old SDK templates are cloned (e.g. #v13.1.1).
                 verbosePrinter?.invoke("Generating ${appSource.template} Template App ($packagerVersion)")
                 "https://github.com/$org/SalesforceMobileSDK-Templates/${appSource.template}#$packagerVersion"
             } else {

--- a/TestOrchestrator/src/main/kotlin/AppGenerator.kt
+++ b/TestOrchestrator/src/main/kotlin/AppGenerator.kt
@@ -40,6 +40,7 @@ fun generateApp(
     useSF: Boolean,
     packagerDir: String = "SalesforceMobileSDK-Package",
     packagerVersion: String? = null,
+    org: String = FORCE_DOT_COM_ORG,
 ): AppInfo {
     val generationCommand = mutableListOf(
         "./$packagerDir/test/test_force.js",
@@ -65,7 +66,7 @@ fun generateApp(
                 // Old packager for upgrade testing: use the version tag so the
                 // old SDK templates are cloned (e.g. #v13.1.1).
                 verbosePrinter?.invoke("Generating ${appSource.template} Template App ($packagerVersion)")
-                "https://github.com/forcedotcom/SalesforceMobileSDK-Templates/${appSource.template}#$packagerVersion"
+                "https://github.com/$org/SalesforceMobileSDK-Templates/${appSource.template}#$packagerVersion"
             } else {
                 verbosePrinter?.invoke("Generating ${appSource.template} Template App")
                 "https://github.com/forcedotcom/SalesforceMobileSDK-Templates/${appSource.template}#\\dev"

--- a/TestOrchestrator/src/main/kotlin/AppUpgrader.kt
+++ b/TestOrchestrator/src/main/kotlin/AppUpgrader.kt
@@ -44,7 +44,7 @@ fun performUpgrade(appSource: AppSource, useSF: Boolean, debug: Boolean) {
  * into a separate directory for generating apps from an older SDK version.
  * Returns the directory name.
  */
-fun setupOldPackager(version: String): String {
+fun setupOldPackager(version: String, org: String = FORCE_DOT_COM_ORG): String {
     val dir = File(OLD_PACKAGER_DIR)
     if (dir.exists()) {
         dir.deleteRecursively()
@@ -60,7 +60,7 @@ fun setupOldPackager(version: String): String {
         "git", "clone",
         "--branch", version,
         "--single-branch", "--depth", "1",
-        "https://github.com/forcedotcom/SalesforceMobileSDK-Package.git",
+        "https://github.com/$org/SalesforceMobileSDK-Package.git",
         OLD_PACKAGER_DIR,
     ).runCommand()
     if (cloneResult != 0) {

--- a/TestOrchestrator/src/main/kotlin/Main.kt
+++ b/TestOrchestrator/src/main/kotlin/Main.kt
@@ -75,6 +75,7 @@ const val ANDROID_MAX_API_LEVEL = 36
 const val DEFAULT_IOS_VERSION = "26"
 const val DEFAULT_IOS_DEVICE = "iPhone-SE-3rd-generation"
 const val OLD_PACKAGER_DIR = "SalesforceMobileSDK-Package-Old"
+const val FORCE_DOT_COM_ORG = "forcedotcom"
 
 // Aliases for templates whose repo name doesn't match the convention used
 // by the rest of the templates (e.g. MobileSyncExplorer{Swift,ReactNative}
@@ -141,8 +142,11 @@ class TestOrchestrator : CliktCommand() {
     val preserverGeneratedApps: Boolean by option("-p", "--preserverGeneratedApps").flag()
         .help("Do not cleanup generated apps from previous runs.")
     val upgradeFrom: String? by option("-u", "--upgrade", "--upgradeFrom")
-        .help("Run an upgrade test. Provide the SDK version/branch/tag to upgrade FROM (e.g. '12.1.0')." +
+        .help("Run an upgrade test. Provide the SDK version (as a branch or tag) to upgrade FROM (e.g. 'v12.1.0')." +
                 "\u0085The app is generated with this version, logged in, then upgraded to dev and verified.")
+    val sdkVersion: String? by option("--sdk", "--sdkVersion")
+        .help("Generate and test the app using a specific SDK branch or tag (e.g. 'master', 'v13.2.0')." +
+                "\u0085You can optionally specify the Github org with a '/' (e.g 'brandonpage/my-feature-branch')")
     val useFirebase: Boolean by option("-f", "--firebase").boolean()
         .defaultLazy { IS_CI && upgradeFrom.isNullOrBlank() }
         .help("Run Android tests in Firebase Test Lab. Defaults to on for CI and off otherwise.")
@@ -186,6 +190,14 @@ class TestOrchestrator : CliktCommand() {
         if (upgradeFrom != null && reRunTest) {
             throw UsageError("--upgrade cannot be combined with --reRun.")
         }
+
+        if (sdkVersion != null && upgradeFrom != null) {
+            throw UsageError("--sdkVersion cannot be combined with --upgrade.")
+        }
+        if (sdkVersion != null && reRunTest) {
+            throw UsageError("--sdkVersion cannot be combined with --reRun.")
+        }
+
 
         if (!reRunTest) {
             val tmpDirs = File(".").listFiles { files ->
@@ -245,6 +257,10 @@ class TestOrchestrator : CliktCommand() {
                     if (appSource.isComplexHybrid) totalSteps++
                     if (appSource.isReact) totalSteps++
                 }
+                if (sdkVersion != null) {
+                    // sdkVersion adds: clone packager step
+                    totalSteps++
+                }
 
                 progressBanner = progressBarContextLayout<ProgressState> {
                     text {
@@ -286,10 +302,10 @@ class TestOrchestrator : CliktCommand() {
                 }.animateOnThread(
                     terminal,
                     context = ProgressState(
-                        currentStep = if (upgradeFrom != null) {
-                            "Clone Packager ($upgradeFrom)"
-                        } else {
-                            "Generate App"
+                        currentStep = when {
+                            upgradeFrom != null -> "Clone Packager ($upgradeFrom)"
+                            sdkVersion != null -> "Clone Packager ($sdkVersion)"
+                            else -> "Generate App"
                         }
                     ),
                     total = totalSteps,
@@ -309,6 +325,22 @@ class TestOrchestrator : CliktCommand() {
                             packagerVersion = upgradeFrom,
                         )
                         relocateApp(oldAppInfo, upgradeFrom!!)
+                    } else if (sdkVersion != null) {
+                        // Version test: Generate with specific SDK branch/tag
+                        // Support fork syntax: "owner/branch" or plain "branch"
+                        val (sdkOrg, sdkBranch) = if ('/' in sdkVersion!!) {
+                            sdkVersion!!.substringBefore('/') to sdkVersion!!.substringAfter('/')
+                        } else {
+                            FORCE_DOT_COM_ORG to sdkVersion!!
+                        }
+                        val packager = setupOldPackager(sdkBranch, org = sdkOrg)
+                        generateApp(
+                            appSource,
+                            useSF,
+                            packagerDir = packager,
+                            packagerVersion = sdkBranch,
+                            org = sdkOrg,
+                        )
                     } else {
                         generateApp(appSource, useSF)
                     }

--- a/TestOrchestrator/src/main/kotlin/Main.kt
+++ b/TestOrchestrator/src/main/kotlin/Main.kt
@@ -36,7 +36,6 @@ import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.arguments.help
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.arguments.unique
-import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.defaultLazy
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.help
@@ -83,10 +82,6 @@ const val FORCE_DOT_COM_ORG = "forcedotcom"
 private val TEMPLATE_ALIASES = mapOf(
     "mobilesyncexplorerkotlin" to "MobileSyncExplorerKotlinTemplate",
 )
-
-private fun resolveTemplateAlias(input: String): String =
-    TEMPLATE_ALIASES[input.lowercase()] ?: input
-
 
 class TestOrchestrator : CliktCommand() {
 
@@ -146,7 +141,10 @@ class TestOrchestrator : CliktCommand() {
                 "\u0085The app is generated with this version, logged in, then upgraded to dev and verified.")
     val sdkVersion: String? by option("--sdk", "--sdkVersion")
         .help("Generate and test the app using a specific SDK branch or tag (e.g. 'master', 'v13.2.0')." +
-                "\u0085You can optionally specify the Github org with a '/' (e.g 'brandonpage/my-feature-branch')")
+                "\u0085Optionally specify a Packager fork org with '/' (e.g. 'brandonpage/my-feature-branch').")
+    val templateBranch: String? by option("-b", "--templateBranch")
+        .help("Generate the app (to test) using a specific branch.  The dev packager is used. " +
+                "\u0085Optionally specify a fork org with '/' (e.g. 'brandonpage/my-feature-branch').")
     val useFirebase: Boolean by option("-f", "--firebase").boolean()
         .defaultLazy { IS_CI && upgradeFrom.isNullOrBlank() }
         .help("Run Android tests in Firebase Test Lab. Defaults to on for CI and off otherwise.")
@@ -197,7 +195,6 @@ class TestOrchestrator : CliktCommand() {
         if (sdkVersion != null && reRunTest) {
             throw UsageError("--sdkVersion cannot be combined with --reRun.")
         }
-
 
         if (!reRunTest) {
             val tmpDirs = File(".").listFiles { files ->
@@ -315,6 +312,13 @@ class TestOrchestrator : CliktCommand() {
 
             try {
                 val appInfo = if (!reRunTest) {
+                    // Resolve template org/branch if --templateBranch is set
+                    val (templateOrg, templateBranch) = if (templateBranch != null) {
+                        parseOrgAndBranch(templateBranch!!)
+                    } else {
+                        FORCE_DOT_COM_ORG to null
+                    }
+
                     if (upgradeFrom != null) {
                         // Upgrade Phase 1: Generate with old SDK version
                         val oldPackager = setupOldPackager(upgradeFrom!!)
@@ -322,24 +326,28 @@ class TestOrchestrator : CliktCommand() {
                             appSource,
                             useSF,
                             packagerDir = oldPackager,
-                            packagerVersion = upgradeFrom,
+                            packagerVersion = templateBranch ?: upgradeFrom,
+                            org = templateOrg,
                         )
                         relocateApp(oldAppInfo, upgradeFrom!!)
                     } else if (sdkVersion != null) {
-                        // Version test: Generate with specific SDK branch/tag
-                        // Support fork syntax: "owner/branch" or plain "branch"
-                        val (sdkOrg, sdkBranch) = if ('/' in sdkVersion!!) {
-                            sdkVersion!!.substringBefore('/') to sdkVersion!!.substringAfter('/')
-                        } else {
-                            FORCE_DOT_COM_ORG to sdkVersion!!
-                        }
+                        // Version test: Clone packager at specific branch/tag
+                        val (sdkOrg, sdkBranch) = parseOrgAndBranch(sdkVersion!!)
                         val packager = setupOldPackager(sdkBranch, org = sdkOrg)
                         generateApp(
                             appSource,
                             useSF,
                             packagerDir = packager,
-                            packagerVersion = sdkBranch,
-                            org = sdkOrg,
+                            packagerVersion = templateBranch ?: sdkBranch,
+                            org = templateOrg,
+                        )
+                    } else if (templateBranch != null) {
+                        // Template-only test: Use dev packager
+                        generateApp(
+                            appSource,
+                            useSF,
+                            packagerVersion = templateBranch,
+                            org = templateOrg,
                         )
                     } else {
                         generateApp(appSource, useSF)
@@ -392,6 +400,14 @@ class TestOrchestrator : CliktCommand() {
             exitProcess(1)
         }
     }
+
+    private fun resolveTemplateAlias(input: String): String =
+        TEMPLATE_ALIASES[input.lowercase()] ?: input
+
+    /** Splits "owner/branch" into (owner, branch), defaulting to forcedotcom. */
+    private fun parseOrgAndBranch(value: String): Pair<String, String> =
+        if ('/' in value) value.substringBefore('/') to value.substringAfter('/')
+        else FORCE_DOT_COM_ORG to value
 
     companion object {
 


### PR DESCRIPTION
I just sent a PR to the UITest repo that should be a very useful.  It adds:

```
  --sdk, --sdkVersion=<text>           Generate and test the app using a specific SDK branch or tag (e.g. 'master', 'v13.2.0').
                                       Optionally specify a Packager fork org with '/' (e.g. 'brandonpage/my-feature-branch').
```

There are several use cases for this:

1. Patch Testing (my primary motivation).  The new version-test.yaml adds a workflow dispatch that lets you specify the branch to run the full regression suite against all apps.
2. A customer reports an issue for a specific version of an app.  Generated it with this instead of cloning an old version of a main repo or installing an old forcedroid/ios/etc cli.
3.  Easily test Packager repo changes with this before sending the PR by pointing it to the branch on your fork.

And as a bonus:
```
  -b, --templateBranch=<text>          Generate the app (to test) using a specific branch. The dev packager is used.
                                       Optionally specify a fork org with '/' (e.g. 'brandonpage/my-feature-branch').
```

This is a convenient way to test version bumps or small template changes without having to mess with modifying a packager clone to build the template from your fork.