### PR TITLE
Fix security issues

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -14,6 +14,14 @@ on:
       is_pr:
         type: boolean
         default: false
+    secrets:
+      ANDROID_UI_TEST_CONFIG:
+        required: true
+      GCLOUD_SERVICE_KEY:
+        required: true
+
+permissions:
+  contents: read
 
 jobs:
   test-android:
@@ -22,23 +30,25 @@ jobs:
     env:
       GCLOUD_RESULTS_DIR: "UITest-${{ inputs.app }}-sfdx-${{ inputs.sfdx }}-build-${{ github.run_number }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           # We need a sufficient depth or Danger will occasionally run into issues checking which files were modified.
           fetch-depth: 100
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.14.3"
           add-job-summary: on-failure
@@ -49,29 +59,34 @@ jobs:
         run: |
           ./install.sh
           echo $ANDROID_UI_TEST_CONFIG > ./shared/test/android/ui_test_config.json
-      - uses: 'google-github-actions/auth@v2'
+      - uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed'  # v2.1.13
         if: success() || failure()
         with:
           credentials_json: '${{ secrets.GCLOUD_SERVICE_KEY }}'
-      - uses: 'google-github-actions/setup-gcloud@v2'
+      - uses: 'google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f'  # v2.2.1
         if: success() || failure()
       - name: Build ${{ inputs.app }} and Test Login
+        env:
+          APP: ${{ inputs.app }}
+          SFDX_INPUT: ${{ inputs.sfdx }}
+          SDK_VERSION_INPUT: ${{ inputs.sdkVersion }}
         run: |
-          SFDX=""
-
-          if ${{ inputs.sfdx }} ; then
-            SFDX="--sf"
+          SFDX_FLAG=""
+          if [ "$SFDX_INPUT" = "true" ]; then
+            SFDX_FLAG="--sf"
           fi
 
-          SDK_VERSION=""
-          if [ -n "${{ inputs.sdkVersion }}" ]; then
-            SDK_VERSION="--sdkVersion=${{ inputs.sdkVersion }}"
+          SDK_VERSION_FLAG=""
+          if [ -n "$SDK_VERSION_INPUT" ]; then
+            SDK_VERSION_FLAG="--sdkVersion=$SDK_VERSION_INPUT"
           fi
 
-          ./test android ${{ inputs.app }} ${SFDX} ${SDK_VERSION}
+          ./test android "$APP" $SFDX_FLAG $SDK_VERSION_FLAG
       - name: Copy Test Results
         continue-on-error: true
         if: success() || failure()
+        env:
+          APP: ${{ inputs.app }}
         run: |
           mkdir -p firebase_results
           BUCKET="gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw"
@@ -119,10 +134,10 @@ jobs:
           }
 
           if gsutil ls "${BUCKET_PATH}" > /dev/null 2>&1; then
-            copy_results_by_api_level "${BUCKET_PATH}" "${{ inputs.app }}"
+            copy_results_by_api_level "${BUCKET_PATH}" "$APP"
           fi
       - name: Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()
         with:
           check_name: ${{ inputs.app }} Test Results
@@ -138,7 +153,7 @@ jobs:
           simplified_summary: true
           report_paths: 'firebase_results/**.xml'
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: success() || failure()
         with:
           name: test-results-${{ inputs.app }}-android-sfdx-${{ inputs.sfdx }}

--- a/.github/workflows/android-upgrade-reusable-workflow.yaml
+++ b/.github/workflows/android-upgrade-reusable-workflow.yaml
@@ -12,22 +12,29 @@ on:
         type: string
         default: "35"
         description: "Android API level for the emulator"
+    secrets:
+      ANDROID_UI_TEST_CONFIG:
+        required: true
+
+permissions:
+  contents: read
 
 jobs:
   test-android-upgrade:
     name: ${{ inputs.app }} API ${{ inputs.api-level }} Upgrade from ${{ inputs.upgradeFrom }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.14.3"
           add-job-summary: on-failure
@@ -43,7 +50,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         id: avd-cache
         with:
           path: |
@@ -52,7 +59,7 @@ jobs:
           key: avd-api-${{ inputs.api-level }}-${{ runner.os }}
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a  # v2.37.0
         with:
           api-level: ${{ inputs.api-level }}
           arch: x86_64
@@ -61,7 +68,7 @@ jobs:
           disable-animations: true
           script: echo "Generated AVD snapshot for caching."
       - name: Build ${{ inputs.app }}, Login, Upgrade from ${{ inputs.upgradeFrom }} and Test
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a  # v2.37.0
         with:
           api-level: ${{ inputs.api-level }}
           arch: x86_64
@@ -70,7 +77,7 @@ jobs:
           disable-animations: true
           script: ./test android ${{ inputs.app }} --upgrade=${{ inputs.upgradeFrom }}
       - name: Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()
         with:
           check_name: ${{ inputs.app }} API ${{ inputs.api-level }} Upgrade Test Results
@@ -86,7 +93,7 @@ jobs:
           simplified_summary: true
           report_paths: 'Android/app/build/outputs/androidTest-results/**/*.xml'
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: success() || failure()
         with:
           name: test-results-${{ inputs.app }}-android-api-${{ inputs.api-level }}-upgrade-${{ inputs.upgradeFrom }}

--- a/.github/workflows/ios-reusable-workflow.yaml
+++ b/.github/workflows/ios-reusable-workflow.yaml
@@ -25,17 +25,26 @@ on:
         type: string
         default: ""
         description: "SDK branch/tag to generate and test (leave empty for dev)"
+    secrets:
+      IOS_UI_TEST_CONFIG:
+        required: true
+
+permissions:
+  contents: read
 
 jobs:
   test-ios:
     name: ${{ inputs.app }} iOS ${{ inputs.ios }}${{ inputs.upgradeFrom != '' && format(' Upgrade from {0}', inputs.upgradeFrom) || '' }}
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
         if: ${{ ! inputs.is_pr }}
       - name: Free Disk Space
         run: |
@@ -58,23 +67,28 @@ jobs:
       - name: Build ${{ inputs.app }}${{ inputs.upgradeFrom != '' && format(', Login, Upgrade from {0} and Test', inputs.upgradeFrom) || ' and Test Login' }} (iOS ${{ inputs.ios }})
         env:
           GITHUB_RUN_NUM: ${{ github.run_number }}
+          APP: ${{ inputs.app }}
+          IOS: ${{ inputs.ios }}
+          SFDX_INPUT: ${{ inputs.sfdx }}
+          UPGRADE_FROM_INPUT: ${{ inputs.upgradeFrom }}
+          SDK_VERSION_INPUT: ${{ inputs.sdkVersion }}
         run: |
-          SFDX=""
-          if ${{ inputs.sfdx }} ; then
-            SFDX="--sf"
+          SFDX_FLAG=""
+          if [ "$SFDX_INPUT" = "true" ] ; then
+            SFDX_FLAG="--sf"
           fi
 
-          UPGRADE=""
-          if [ -n "${{ inputs.upgradeFrom }}" ]; then
-            UPGRADE="--upgrade=${{ inputs.upgradeFrom }}"
+          UPGRADE_FLAG=""
+          if [ -n "$UPGRADE_FROM_INPUT" ]; then
+            UPGRADE_FLAG="--upgrade=$UPGRADE_FROM_INPUT"
           fi
 
-          SDK_VERSION=""
-          if [ -n "${{ inputs.sdkVersion }}" ]; then
-            SDK_VERSION="--sdkVersion=${{ inputs.sdkVersion }}"
+          SDK_VERSION_FLAG=""
+          if [ -n "$SDK_VERSION_INPUT" ]; then
+            SDK_VERSION_FLAG="--sdkVersion=$SDK_VERSION_INPUT"
           fi
 
-          ./test ios ${{ inputs.app }} --ios "${{ inputs.ios }}" ${SFDX} ${UPGRADE} ${SDK_VERSION}
+          ./test ios "$APP" --ios "$IOS" $SFDX_FLAG $UPGRADE_FLAG $SDK_VERSION_FLAG
       - name: Convert Test Results to JUnit XML
         if: success() || failure()
         run: |
@@ -122,7 +136,7 @@ jobs:
           PYEOF
           done >> $GITHUB_STEP_SUMMARY
       - name: Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()
         with:
           check_name: ${{ inputs.app }} iOS ${{ inputs.ios }}${{ inputs.upgradeFrom != '' && ' Upgrade' || '' }} Test Results
@@ -138,7 +152,7 @@ jobs:
           simplified_summary: true
           report_paths: 'ios_results/**.xml'
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: success() || failure()
         with:
           name: test-results-${{ inputs.app }}-ios-${{ inputs.ios }}${{ inputs.upgradeFrom != '' && format('-upgrade-{0}', inputs.upgradeFrom) || format('-sfdx-{0}', inputs.sfdx) }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   android-base:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} Android
     strategy:
       fail-fast: false
@@ -24,6 +26,8 @@ jobs:
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   android-sfdx:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} Android sfdx
     strategy:
       fail-fast: false
@@ -38,6 +42,8 @@ jobs:
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   ios-base-legacy:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS 18
     strategy:
       fail-fast: false
@@ -52,6 +58,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios-base:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS 26
     strategy:
       fail-fast: false
@@ -65,6 +73,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios-sfdx:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS sfdx
     strategy:
       fail-fast: false
@@ -78,6 +88,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   android-upgrade:
+    permissions:
+      contents: read
     # Run upgrade tests after so standard login's don't revoke upgrade refresh
     # tokens mid-execution by hitting the user session limit.
     needs: [android-base, android-sfdx]
@@ -101,6 +113,8 @@ jobs:
       ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
 
   ios-upgrade:
+    permissions:
+      contents: read
     # If macos runner concurrency limit increases run these after standard login like Android.
     name: ${{ matrix.app }} iOS Upgrade from ${{ matrix.upgradeFrom }}
     strategy:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,10 +1,13 @@
 name: Build and Test All Apps
 
-on: 
+on:
   schedule:
     - cron: "0 6 * * 0"  # cron is UTC, this translates to 10 PM PST Saturday.
   # This lets us trigger the workflow from a browser.
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   android-base:
@@ -16,7 +19,9 @@ jobs:
     uses: ./.github/workflows/android-reusable-workflow.yaml
     with:
       app: ${{ matrix.app }}
-    secrets: inherit
+    secrets:
+      ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   android-sfdx:
     name: ${{ matrix.app }} Android sfdx
@@ -28,8 +33,10 @@ jobs:
     with:
       app: ${{ matrix.app }}
       sfdx: true
-    secrets: inherit
-    
+    secrets:
+      ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+
   ios-base-legacy:
     name: ${{ matrix.app }} iOS 18
     strategy:
@@ -41,7 +48,8 @@ jobs:
       app: ${{ matrix.app }}
       ios: "18"
       runner: macos-15
-    secrets: inherit
+    secrets:
+      IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios-base:
     name: ${{ matrix.app }} iOS 26
@@ -53,7 +61,8 @@ jobs:
     with:
       app: ${{ matrix.app }}
       ios: "26"
-    secrets: inherit
+    secrets:
+      IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios-sfdx:
     name: ${{ matrix.app }} iOS sfdx
@@ -65,7 +74,8 @@ jobs:
     with:
       app: ${{ matrix.app }}
       sfdx: true
-    secrets: inherit
+    secrets:
+      IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   android-upgrade:
     # Run upgrade tests after so standard login's don't revoke upgrade refresh
@@ -87,7 +97,8 @@ jobs:
     with:
       app: ${{ matrix.app }}
       upgradeFrom: ${{ matrix.upgradeFrom }}
-    secrets: inherit
+    secrets:
+      ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
 
   ios-upgrade:
     # If macos runner concurrency limit increases run these after standard login like Android.
@@ -104,4 +115,5 @@ jobs:
     with:
       app: ${{ matrix.app }}
       upgradeFrom: ${{ matrix.upgradeFrom }}
-    secrets: inherit
+    secrets:
+      IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,6 +38,8 @@ jobs:
           fi
 
   ios-pr:
+    permissions:
+      contents: read
     needs: [permission-check]
     strategy:
       fail-fast: false
@@ -51,6 +53,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   android-pr:
+    permissions:
+      contents: read
     needs: [permission-check]
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,30 +1,39 @@
 name: Pull Request
 
 on:
-  # Dangerous without Member Check setup!
-  pull_request_target:
+  # pull_request_target required for fork PRs to receive secrets.
+  # Mitigated by permission-check job's Member Check pattern.
+  pull_request_target:  # zizmor: ignore[dangerous-triggers]
     branches: [master]
+
+permissions:
+  contents: read
 
 jobs:
   permission-check:
     runs-on: ubuntu-latest
     steps:
       - name: Check Write Permission
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
         id: check_permissions
         with:
           route: GET /repos/${{ github.repository }}/collaborators/${{ github.triggering_actor }}/permission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Debug Permission Response
+        env:
+          PERMISSION_DATA: ${{ steps.check_permissions.outputs.data }}
         run: |
-          echo "Permission raw response: ${{ steps.check_permissions.outputs.data }}"
+          echo "Permission raw response: $PERMISSION_DATA"
       - name: Validate Write Permission
+        env:
+          PERMISSION_DATA: ${{ steps.check_permissions.outputs.data }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
-          permission=$(echo "${{ fromJson(steps.check_permissions.outputs.data).permission }}")
-          echo "User ${{ github.triggering_actor }} has permission: $permission"
+          permission=$(echo "$PERMISSION_DATA" | jq -r '.permission // empty')
+          echo "User $TRIGGERING_ACTOR has permission: $permission"
           if [[ "$permission" != "write" && "$permission" != "admin" ]]; then
-            echo "User ${{ github.triggering_actor }} does not have sufficient permission (write or admin) to proceed. Someone from the team needs to rerun this workflow AFTER it has been deemed safe."
+            echo "User $TRIGGERING_ACTOR does not have sufficient permission (write or admin) to proceed. Someone from the team needs to rerun this workflow AFTER it has been deemed safe."
             exit 1
           fi
 
@@ -38,7 +47,8 @@ jobs:
     with:
       app: ${{ matrix.app }}
       is_pr: true
-    secrets: inherit
+    secrets:
+      IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   android-pr:
     needs: [permission-check]
@@ -50,4 +60,6 @@ jobs:
     with:
       app: ${{ matrix.app }}
       is_pr: true
-    secrets: inherit
+    secrets:
+      ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}

--- a/.github/workflows/version-test.yaml
+++ b/.github/workflows/version-test.yaml
@@ -13,6 +13,8 @@ permissions:
 
 jobs:
   android:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} Android
     strategy:
       fail-fast: false
@@ -27,6 +29,8 @@ jobs:
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   ios-legacy:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS 18
     strategy:
       fail-fast: false
@@ -43,6 +47,8 @@ jobs:
       IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios:
+    permissions:
+      contents: read
     name: ${{ matrix.app }} iOS 26
     strategy:
       fail-fast: false

--- a/.github/workflows/version-test.yaml
+++ b/.github/workflows/version-test.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   android:
     name: ${{ matrix.app }} Android
@@ -19,7 +22,9 @@ jobs:
     with:
       app: ${{ matrix.app }}
       sdkVersion: ${{ inputs.sdkVersion }}
-    secrets: inherit
+    secrets:
+      ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
   ios-legacy:
     name: ${{ matrix.app }} iOS 18
@@ -34,7 +39,8 @@ jobs:
       ios: ${{ matrix.ios }}
       runner: macos-15
       sdkVersion: ${{ inputs.sdkVersion }}
-    secrets: inherit
+    secrets:
+      IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}
 
   ios:
     name: ${{ matrix.app }} iOS 26
@@ -47,4 +53,5 @@ jobs:
       app: ${{ matrix.app }}
       ios: "26"
       sdkVersion: ${{ inputs.sdkVersion }}
-    secrets: inherit
+    secrets:
+      IOS_UI_TEST_CONFIG: ${{ secrets.IOS_UI_TEST_CONFIG }}


### PR DESCRIPTION
## Summary

Implements [W-22712082 — Cleanup CI for all Repos](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002b3viMYAQ/view).

**Schedule**: unchanged (`0 6 * * 0` UTC, Saturday 10 PM PT). The repo has had 0 commits in the last 180 days and runs cross-repo integration tests after the per-repo workflows have validated their own changes — weekly cadence is appropriate.

**Security hardening**: All workflows updated to follow the [GitHub Actions injection-prevention best practices](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/):

- **All third-party actions SHA-pinned** with the resolved tag in a comment.
- **Top-level `permissions: contents: read`** added to every workflow.
- **`secrets: inherit` replaced with explicit secret pass-through**. Reusable workflows now declare expected secrets in `on: workflow_call: secrets:` (`ANDROID_UI_TEST_CONFIG`/`GCLOUD_SERVICE_KEY` for android, `IOS_UI_TEST_CONFIG` for iOS, `ANDROID_UI_TEST_CONFIG` for android-upgrade).
- **All `${{ ... }}` shell interpolation** in `run:` blocks refactored to `env:` variables with quoted shell expansions. Notable refactors: the `Build` step in both reusable workflows (uses `inputs.app`/`inputs.sfdx`/`inputs.sdkVersion`/`inputs.upgradeFrom`/`inputs.ios`); the `Validate Write Permission` step in `pr.yaml` (now uses `jq` shell-side instead of inline `${{ fromJson(...) }}`).
- **`pull_request_target`** retained with `# zizmor: ignore[dangerous-triggers]` and inline comment documenting the permission-check mitigation.
- **`actions/checkout` steps** set `with: persist-credentials: false`.
- **Job-level `permissions:` on reusable-workflow callers** in `nightly.yaml`, `pr.yaml`, and `version-test.yaml`.

After this change, `zizmor --offline` reports 0 High-confidence findings across all six CI workflows.

## Test plan

- [x] Verified locally with `python3 yaml.safe_load`, `actionlint -shellcheck=`, `zizmor --offline`. All clean.
- [x] CI verification: opened test PR on personal fork (`brandonpage/SalesforceMobileSDK-UITests#6`) targeting the same `cleanup-ci-w22712082` branch as this PR. The test PR triggers the new workflows against a real source change in `iOS/Util/UITestConfig.swift`. **No regressions observed** — see linked PR for run details.
- [ ] Reviewer to confirm the `permissions:` blocks match the team's expected privilege levels for each workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
