### PR TITLE
Bump Android minSdk to 31

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -17,7 +17,7 @@ android {
     namespace 'com.salesforce.mobilesdk.mobilesdkuitest'
     compileSdk 35
     defaultConfig {
-        minSdkVersion 28
+        minSdkVersion 31
         targetSdkVersion 35
         versionCode 1
         versionName '1.0'

--- a/TestOrchestrator/src/main/kotlin/Main.kt
+++ b/TestOrchestrator/src/main/kotlin/Main.kt
@@ -69,7 +69,7 @@ import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.pathString
 import kotlin.system.exitProcess
 
-const val ANDROID_MIN_API_LEVEL = 28
+const val ANDROID_MIN_API_LEVEL = 31
 const val ANDROID_MAX_API_LEVEL = 36
 const val DEFAULT_IOS_VERSION = "26"
 const val DEFAULT_IOS_DEVICE = "iPhone-SE-3rd-generation"


### PR DESCRIPTION
## Summary
- Bumps `minSdkVersion` in `Android/app/build.gradle` from 28 to 31.
- Bumps `ANDROID_MIN_API_LEVEL` in TestOrchestrator from 28 to 31 (drives the Firebase Test Lab device range, now 31..36).

Aligns with the matching bumps in the Android, CordovaPlugin, ReactNative, and Templates repos.

## Test plan
- [ ] CI: Android workflow runs against API 31..36 only
- [ ] Manual: TestOrchestrator login tests pass against the new range

🤖 Generated with [Claude Code](https://claude.com/claude-code)