### PR TITLE
Bump Android minSdk to 31

### DIFF
--- a/.github/workflows/android-upgrade-reusable-workflow.yaml
+++ b/.github/workflows/android-upgrade-reusable-workflow.yaml
@@ -10,7 +10,7 @@ on:
         description: "SDK version/branch/tag to upgrade FROM"
       api-level:
         type: string
-        default: "35"
+        default: "36"
         description: "Android API level for the emulator"
     secrets:
       ANDROID_UI_TEST_CONFIG:

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -15,10 +15,10 @@ buildscript {
 
 android {
     namespace 'com.salesforce.mobilesdk.mobilesdkuitest'
-    compileSdk 37
+    compileSdk 36
     defaultConfig {
         minSdkVersion 31
-        targetSdkVersion 37
+        targetSdkVersion 36
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -15,10 +15,10 @@ buildscript {
 
 android {
     namespace 'com.salesforce.mobilesdk.mobilesdkuitest'
-    compileSdk 35
+    compileSdk 37
     defaultConfig {
-        minSdkVersion 28
-        targetSdkVersion 35
+        minSdkVersion 31
+        targetSdkVersion 37
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -42,10 +42,10 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    androidTestImplementation 'androidx.test:runner:1.6.2'
-    androidTestImplementation 'androidx.test:core:1.6.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    androidTestImplementation 'androidx.test:runner:1.7.0'
+    androidTestImplementation 'androidx.test:core:1.7.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
-    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3'
+    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0'
 }

--- a/TestOrchestrator/build.gradle.kts
+++ b/TestOrchestrator/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation("com.github.ajalt.clikt:clikt:$mordantVersion")
     implementation("com.github.ajalt.clikt:clikt-markdown:$mordantVersion")
     implementation("com.github.ajalt.mordant:mordant-coroutines:3.0.2")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 }
 
 application {

--- a/TestOrchestrator/src/main/kotlin/Main.kt
+++ b/TestOrchestrator/src/main/kotlin/Main.kt
@@ -69,7 +69,7 @@ import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.pathString
 import kotlin.system.exitProcess
 
-const val ANDROID_MIN_API_LEVEL = 28
+const val ANDROID_MIN_API_LEVEL = 31
 const val ANDROID_MAX_API_LEVEL = 36
 const val DEFAULT_IOS_VERSION = "26"
 const val DEFAULT_IOS_DEVICE = "iPhone-SE-3rd-generation"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Thu Jun 04 17:47:46 PDT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Bumps `minSdkVersion` in `Android/app/build.gradle` from 28 to 31; bumps `compileSdk` and `targetSdkVersion` to 36.
- Bumps `ANDROID_MIN_API_LEVEL` in TestOrchestrator from 28 to 31 (drives the Firebase Test Lab device range, now 31..36).
- Bumps `kotlinx-serialization-json` from 1.10.0 to 1.11.0.
- Bumps Gradle wrapper from 8.14.3 to 9.4.1.
- Bumps the nightly Android upgrade workflow's default `api-level` from 35 to 36.

Aligns with the matching `minSdk` bumps in the Android, CordovaPlugin, ReactNative, and Templates repos.

## Test plan
- [x] CI: Android workflow runs against API 31..36 only
- [x] Manual: TestOrchestrator login tests pass against the new range
- [x] Manual: nightly upgrade tests succeed at API 36