### PR TITLE
Use forcedotcom-ubuntu runner for Linux CI jobs

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   test-android:
     name: ${{ inputs.app }}
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     env:
       GCLOUD_RESULTS_DIR: "UITest-${{ inputs.app }}-sfdx-${{ inputs.sfdx }}-build-${{ github.run_number }}"
     steps:

--- a/.github/workflows/android-upgrade-reusable-workflow.yaml
+++ b/.github/workflows/android-upgrade-reusable-workflow.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   test-android-upgrade:
     name: ${{ inputs.app }} API ${{ inputs.api-level }} Upgrade from ${{ inputs.upgradeFrom }}
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   permission-check:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     steps:
       - name: Check Write Permission
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0


### PR DESCRIPTION
## What
Switch all Linux GitHub Actions jobs from the public `ubuntu-latest` runner to the `forcedotcom-ubuntu` enterprise premium runner. macOS jobs are unchanged (there is no `forcedotcom-macos` runner).

## Why
`forcedotcom-ubuntu` supports much higher concurrency (~50 concurrent jobs) than the public pool, which our workflows have been hitting limits on as PR volume grew.

## Notes
- `forcedotcom-ubuntu` is scoped to the `forcedotcom` org — **personal forks cannot schedule it**. Each changed line carries an inline comment reminding fork contributors to swap back to `ubuntu-latest` for fork-based CI testing.
- Verified with a full nightly run on the org-scoped runner (in `SalesforceMobileSDK-UITests`): all Linux jobs picked up runners and ran concurrently, building apps and dispatching to Firebase Test Lab. Remaining test failures were pre-existing login/session flakes — present on the unchanged macOS jobs and the baseline `master` nightly too — and are unrelated to the runner change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
