### PR TITLE
Drive browser-based Advanced Auth in UITests; add hostless redirect E2E case

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -11,6 +11,10 @@ on:
         type: string
         default: ""
         description: "SDK branch/tag to generate and test (leave empty for dev)"
+      appConfig:
+        type: string
+        default: ""
+        description: "OAuth app config from ui_test_config.json (e.g. eca_opaque_hostless); empty uses the orchestrator default"
       is_pr:
         type: boolean
         default: false
@@ -28,7 +32,7 @@ jobs:
     name: ${{ inputs.app }}
     runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     env:
-      GCLOUD_RESULTS_DIR: "UITest-${{ inputs.app }}-sfdx-${{ inputs.sfdx }}-build-${{ github.run_number }}"
+      GCLOUD_RESULTS_DIR: "UITest-${{ inputs.app }}-sfdx-${{ inputs.sfdx }}${{ inputs.appConfig != '' && format('-{0}', inputs.appConfig) || '' }}-build-${{ github.run_number }}"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
@@ -70,6 +74,7 @@ jobs:
           APP: ${{ inputs.app }}
           SFDX_INPUT: ${{ inputs.sfdx }}
           SDK_VERSION_INPUT: ${{ inputs.sdkVersion }}
+          APP_CONFIG_INPUT: ${{ inputs.appConfig }}
         run: |
           SFDX_FLAG=""
           if [ "$SFDX_INPUT" = "true" ]; then
@@ -81,7 +86,12 @@ jobs:
             SDK_VERSION_FLAG="--sdkVersion=$SDK_VERSION_INPUT"
           fi
 
-          ./test android "$APP" $SFDX_FLAG $SDK_VERSION_FLAG
+          APP_CONFIG_FLAG=""
+          if [ -n "$APP_CONFIG_INPUT" ]; then
+            APP_CONFIG_FLAG="--appConfig=$APP_CONFIG_INPUT"
+          fi
+
+          ./test android "$APP" $SFDX_FLAG $SDK_VERSION_FLAG $APP_CONFIG_FLAG
       - name: Copy Test Results
         continue-on-error: true
         if: success() || failure()
@@ -140,8 +150,8 @@ jobs:
         uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         if: success() || failure()
         with:
-          check_name: ${{ inputs.app }} Test Results
-          job_name: ${{ inputs.app }} Test Results
+          check_name: ${{ inputs.app }}${{ inputs.appConfig != '' && format(' {0}', inputs.appConfig) || '' }} Test Results
+          job_name: ${{ inputs.app }}${{ inputs.appConfig != '' && format(' {0}', inputs.appConfig) || '' }} Test Results
           require_tests: true
           check_retries: true
           flaky_summary: true
@@ -156,5 +166,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: success() || failure()
         with:
-          name: test-results-${{ inputs.app }}-android-sfdx-${{ inputs.sfdx }}
+          name: test-results-${{ inputs.app }}-android-sfdx-${{ inputs.sfdx }}${{ inputs.appConfig != '' && format('-{0}', inputs.appConfig) || '' }}
           path: firebase_results/**.xml

--- a/.github/workflows/ios-reusable-workflow.yaml
+++ b/.github/workflows/ios-reusable-workflow.yaml
@@ -157,3 +157,10 @@ jobs:
         with:
           name: test-results-${{ inputs.app }}-ios-${{ inputs.ios }}${{ inputs.upgradeFrom != '' && format('-upgrade-{0}', inputs.upgradeFrom) || format('-sfdx-{0}', inputs.sfdx) }}
           path: ios_results/**.xml
+      - name: Upload Xcode Result Bundles
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        if: failure()
+        with:
+          name: xcresults-${{ inputs.app }}-ios-${{ inputs.ios }}${{ inputs.upgradeFrom != '' && format('-upgrade-{0}', inputs.upgradeFrom) || format('-sfdx-{0}', inputs.sfdx) }}
+          path: iOS/test_output/**
+          if-no-files-found: warn

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -41,6 +41,26 @@ jobs:
       ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
       GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
 
+  android-hostless-redirect:
+    permissions:
+      contents: read
+    # Exercises the genuinely-hostless callback (ecaadvancedopaque:///success/done ->
+    # android:host="") so the generated redirect <intent-filter> is verified to DELIVER
+    # the browser round-trip for the empty-authority shape (W-23294087). Covers the three
+    # distinct manifest-generation paths: native, hybrid injection, and React Native.
+    name: ${{ matrix.app }} Android hostless redirect
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [native_kotlin, hybrid_local, MobileSyncExplorerReactNative]
+    uses: ./.github/workflows/android-reusable-workflow.yaml
+    with:
+      app: ${{ matrix.app }}
+      appConfig: eca_opaque_hostless
+    secrets:
+      ANDROID_UI_TEST_CONFIG: ${{ secrets.ANDROID_UI_TEST_CONFIG }}
+      GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+
   ios-base-legacy:
     permissions:
       contents: read

--- a/Android/app/src/androidTest/java/PageObjects/LoginPageObjects/LoginPageObject.kt
+++ b/Android/app/src/androidTest/java/PageObjects/LoginPageObjects/LoginPageObject.kt
@@ -26,11 +26,7 @@
  */
 package pageobjects.loginpageobjects
 
-import android.os.Build
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM
 import android.util.Log
-import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiSelector
 import pageobjects.BasePageObject
 
@@ -39,51 +35,154 @@ const val PASSWORD_RESOURCE_ID = "password"
 const val LOGIN_RESOURCE_ID = "Login"
 
 /**
+ * Chrome Custom Tab close button. Under forced advanced authentication the login form is rendered
+ * in a Chrome Custom Tab, so its presence is the marker every tab-facing helper keys off.
+ */
+const val CHROME_CLOSE_BUTTON_ID = "com.android.chrome:id/close_button"
+
+/**
+ * Short timeout for checking optional local Chrome UI elements that either appear immediately or
+ * not at all (e.g. first-run dialogs). These are not dependent on server-side rendering.
+ */
+private const val QUICK_CHECK_TIMEOUT: Long = 500
+
+/**
+ * Ceiling for clearing Chrome's First Run Experience, which on a cold profile is a slow multi-page
+ * sequence. Longer than [timeout]; only fully spent when no tab ever appears.
+ */
+private const val FRE_DISMISS_TIMEOUT: Long = 30_000
+
+/**
  * Created by bpage on 2/21/18.
+ *
+ * Drives the Salesforce login form. Under forced advanced authentication the form is rendered in a
+ * Chrome Custom Tab, which runs in a separate process (com.android.chrome) that Espresso cannot
+ * reach; UiAutomator cross-process lookups are used instead. Fields are matched by their web
+ * resource id first, then fall back to the generic EditText/Button classes when Chrome does not
+ * surface the ids (QUERY_ALL_PACKAGES in the androidTest manifest grants the cross-process access).
  */
 class LoginPageObject : BasePageObject() {
 
     fun setUsername(name: String) {
-        Log.i("uia", "Waiting for username filed to be present.")
-        val usernameField = if (SDK_INT == VANILLA_ICE_CREAM) {
-            device.findObject(
-                UiSelector().className("android.widget.EditText").index(0)
-            )
-        } else {
-            device.findObject(UiSelector().resourceId(USERNAME_RESOURCE_ID))
-        }
+        skipGoogleSignIn()
+        Log.i("uia", "Waiting for username field to be present.")
+        var usernameField = device.findObject(UiSelector().resourceId(USERNAME_RESOURCE_ID))
         if (!usernameField.waitForExists(timeout * 5)) {
-            throw AssertionError("Username field not found.")
+            usernameField = device.findObject(
+                UiSelector().className(editTextClass).instance(0)
+            )
+            if (!usernameField.waitForExists(timeout * 5)) {
+                throw AssertionError("Username field not found.")
+            }
         }
+        usernameField.click()
         usernameField.setText(name)
     }
 
     fun setPassword(password: String) {
-        Log.i("uia", "Waiting for password filed to be present.")
-        val passwordField = if (SDK_INT == VANILLA_ICE_CREAM) {
-            device.findObject(
-                UiSelector().className("android.widget.EditText").index(3)
-            )
-        } else {
-            device.findObject(UiSelector().resourceId(PASSWORD_RESOURCE_ID))
-        }
+        skipGoogleSignIn()
+        Log.i("uia", "Waiting for password field to be present.")
+        var passwordField = device.findObject(UiSelector().resourceId(PASSWORD_RESOURCE_ID))
         if (!passwordField.waitForExists(timeout * 5)) {
-            throw AssertionError("Password field not found.")
+            passwordField = device.findObject(
+                UiSelector().className(editTextClass).instance(0)
+            )
+            if (!passwordField.waitForExists(timeout * 5)) {
+                throw AssertionError("Password field not found.")
+            }
         }
+        passwordField.click()
         passwordField.setText(password)
     }
 
     fun tapLogin() {
-        val loginButton = if (SDK_INT == VANILLA_ICE_CREAM) {
-            device.findObject(
+        var loginButton = device.findObject(UiSelector().resourceId(LOGIN_RESOURCE_ID))
+        if (!loginButton.waitForExists(timeout)) {
+            loginButton = device.findObject(
                 UiSelector().className("android.widget.Button").textContains("Log In")
             )
-        } else {
-            device.findObject(UiSelector().resourceId(LOGIN_RESOURCE_ID))
-        }
-        if (!loginButton.waitForExists(timeout)) {
-            throw AssertionError("Log In button not found.")
+            if (!loginButton.waitForExists(timeout)) {
+                throw AssertionError("Log In button not found.")
+            }
         }
         loginButton.click()
+    }
+
+    /**
+     * Clears Chrome's First Run Experience so the Custom Tab can render. On a cold Chrome the tab's
+     * first launch is covered by a multi-page FRE that renders slowly, hiding the tab contents every
+     * tab-facing helper keys off. Loops until the tab is in front, dismissing whichever FRE control
+     * shows each pass. Idempotent: a warm Chrome already showing the tab returns at once.
+     */
+    fun skipGoogleSignIn() {
+        val deadline = System.currentTimeMillis() + FRE_DISMISS_TIMEOUT
+        while (System.currentTimeMillis() < deadline) {
+            if (isCustomTabDisplayed()) {
+                return
+            }
+            if (!dismissOneFreControl()) {
+                // Nothing to dismiss yet; the next FRE page may still be rendering, so re-check.
+                device.waitForIdle(QUICK_CHECK_TIMEOUT)
+            }
+        }
+    }
+
+    /**
+     * Dismisses a single FRE control if one is on screen, returning true if it clicked something.
+     * Decline buttons are tried before accept buttons so the flow advances without a Google sign-in;
+     * each is matched by resource id first, then by its en-locale label.
+     */
+    private fun dismissOneFreControl(): Boolean {
+        val dismissByIdOrText = listOf(
+            "com.android.chrome:id/signin_fre_dismiss_button",
+            "com.android.chrome:id/negative_button",
+        )
+        for (resourceId in dismissByIdOrText) {
+            val button = device.findObject(UiSelector().resourceId(resourceId))
+            if (button.waitForExists(QUICK_CHECK_TIMEOUT)) {
+                button.click()
+                return true
+            }
+        }
+        for (label in listOf("Use without an account", "No thanks", "No Thanks")) {
+            val button = device.findObject(UiSelector().textContains(label))
+            if (button.exists()) {
+                button.click()
+                return true
+            }
+        }
+
+        // The initial UMA/ToS page has no decline option; accepting it is required to advance.
+        val acceptByIdOrText = listOf(
+            "com.android.chrome:id/terms_accept",
+            "com.android.chrome:id/positive_button",
+        )
+        for (resourceId in acceptByIdOrText) {
+            val button = device.findObject(UiSelector().resourceId(resourceId))
+            if (button.waitForExists(QUICK_CHECK_TIMEOUT)) {
+                button.click()
+                return true
+            }
+        }
+        for (label in listOf("Accept & continue", "Got it")) {
+            val button = device.findObject(UiSelector().textContains(label))
+            if (button.exists()) {
+                button.click()
+                return true
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * True when a Chrome Custom Tab is currently in front, detected via its close button.
+     * Used to confirm the advanced-auth login form is being driven in the tab rather than in-app.
+     */
+    fun isCustomTabDisplayed(): Boolean {
+        val closeButton = device.findObject(
+            UiSelector().resourceId(CHROME_CLOSE_BUTTON_ID)
+        )
+        return closeButton.waitForExists(QUICK_CHECK_TIMEOUT)
     }
 }

--- a/Android/app/src/androidTest/java/PageObjects/LoginPageObjects/LoginPageObject.kt
+++ b/Android/app/src/androidTest/java/PageObjects/LoginPageObjects/LoginPageObject.kt
@@ -125,6 +125,7 @@ class LoginPageObject : BasePageObject() {
                 device.waitForIdle(QUICK_CHECK_TIMEOUT)
             }
         }
+        throw AssertionError("Chrome Custom Tab never appeared after ${FRE_DISMISS_TIMEOUT}ms.")
     }
 
     /**

--- a/TestOrchestrator/src/main/kotlin/AppCompiler.kt
+++ b/TestOrchestrator/src/main/kotlin/AppCompiler.kt
@@ -35,46 +35,14 @@ import java.io.File
 fun compileApp(
     appInfo: AppInfo,
     debug: Boolean = false,
-    knownAppConfig: KnownAppConfig = KnownAppConfig.ECA_OPAQUE,
 ) {
-    val testConfig = if (appInfo.os == OS.ANDROID) androidTestConfig else iosTestConfig
-    val loginUrl = testConfig.loginHosts.first().url
-    val appConfig = testConfig.getApp(knownAppConfig)
     val configuration = if (debug) "Debug" else "Release"
 
-    setLoginUrl(appInfo, loginUrl)
-
-    progressBanner?.update {
-        context = context.advance("Set OAuth Config")
-        completed += 1
-    }
-    verbosePrinter?.invoke("Setting OAuth Config")
+    // OAuth config (consumer key, redirect URI, login server) is now injected at
+    // generation time via test_force.js --consumerkey/--callbackurl/--loginserver
+    // (see AppGenerator.generateApp), so there is nothing to patch here anymore.
 
     with(appInfo) {
-        when {
-            isHybrid && os == OS.ANDROID -> {
-                val bootConfig = File(androidRoot, "app/src/main/assets/www/bootconfig.json")
-                updateJsonBootConfig(bootConfig, appConfig)
-            }
-
-            isHybrid && os == OS.IOS -> {
-                val bootConfig = File(iosRoot, "www/bootconfig.json")
-                updateJsonBootConfig(bootConfig, appConfig)
-            }
-
-            os == OS.ANDROID -> {
-                val bootConfig = File(androidRoot, "app/src/main/res/values/bootconfig.xml")
-                updateXmlBootConfig(bootConfig, appConfig)
-            }
-
-            else -> {
-                val resourcesBootConfig = File(iosRoot, "$appName/Resources/bootconfig.plist")
-                val bootConfig = if (resourcesBootConfig.exists()) resourcesBootConfig
-                                 else File(iosRoot, "$appName/bootconfig.plist")
-                updatePlistBootConfig(bootConfig, appConfig)
-            }
-        }
-
         progressBanner?.update {
             context = context.advance("Compile App")
             completed += 1
@@ -109,10 +77,10 @@ fun compileApp(
                 }
             }
             OS.IOS -> {
-                val workspaceOrProject = if (File(iosRoot, "$appName.xcworkspace").exists()) {
-                    listOf("-workspace", "$appName.xcworkspace")
+                val workspaceOrProject = if (File(iosRoot, "$iosXcodeName.xcworkspace").exists()) {
+                    listOf("-workspace", "$iosXcodeName.xcworkspace")
                 } else {
-                    listOf("-project", "$appName.xcodeproj")
+                    listOf("-project", "$iosXcodeName.xcodeproj")
                 }
                 // Older RN templates bundle the fmt library (via Flipper)
                 // which fails to compile with newer Xcode/Clang due to
@@ -120,7 +88,7 @@ fun compileApp(
                 if (isReact) patchFmtConsteval(iosRoot)
 
                 val buildResult = (listOf("xcodebuild", "build") + workspaceOrProject + listOf(
-                    "-scheme", appName,
+                    "-scheme", iosXcodeName,
                     "-sdk", "iphonesimulator",
                     "-destination", "generic/platform=iOS Simulator",
                     "-configuration", configuration,
@@ -136,91 +104,6 @@ fun compileApp(
             }
         }
     }
-}
-
-private fun setLoginUrl(appInfo: AppInfo, loginUrl: String) {
-    progressBanner?.update {
-        context = context.advance("Set Login URL")
-        completed += 1
-    }
-    verbosePrinter?.invoke("Setting Login URL")
-
-    when (appInfo.os) {
-        OS.ANDROID -> {
-            val serversFile = File(appInfo.androidRoot, "app/src/main/res/xml/servers.xml")
-            serversFile.parentFile.mkdirs()
-            serversFile.writeText(
-                """<?xml version="1.0" encoding="utf-8"?>
-                |<servers>
-                |    <server name="Default" url="$loginUrl" />
-                |</servers>
-                |""".trimMargin()
-            )
-        }
-        OS.IOS -> {
-            val plistName = if (appInfo.isHybrid) "${appInfo.appName}-Info.plist" else "Info.plist"
-            val plistPath = File(appInfo.iosRoot, "${appInfo.appName}/$plistName")
-            val loginHost = loginUrl.removePrefix("https://").removePrefix("http://")
-            val content = plistPath.readText()
-            val key = "<key>SFDCOAuthLoginHost</key>"
-
-            if (content.contains(key)) {
-                plistPath.writeText(
-                    content.replace(
-                        Regex("""(<key>SFDCOAuthLoginHost</key>\s*<string>)[^<]*(</string>)"""),
-                        "$1$loginHost$2"
-                    )
-                )
-            } else {
-                // Insert before closing </dict>
-                plistPath.writeText(
-                    content.replace(
-                        "</dict>",
-                        "\t<key>SFDCOAuthLoginHost</key>\n\t<string>$loginHost</string>\n</dict>"
-                    )
-                )
-            }
-        }
-    }
-}
-
-private fun updateXmlBootConfig(file: File, appConfig: AppConfig) {
-    var content = file.readText()
-    content = content.replace(
-        Regex("""(<string name="remoteAccessConsumerKey">)[^<]*(</string>)"""),
-        "$1${appConfig.consumerKey}$2"
-    )
-    content = content.replace(
-        Regex("""(<string name="oauthRedirectURI">)[^<]*(</string>)"""),
-        "$1${appConfig.redirectUri}$2"
-    )
-    file.writeText(content)
-}
-
-private fun updatePlistBootConfig(file: File, appConfig: AppConfig) {
-    var content = file.readText()
-    content = content.replace(
-        Regex("""(<key>remoteAccessConsumerKey</key>\s*<string>)[^<]*(</string>)"""),
-        "$1${appConfig.consumerKey}$2"
-    )
-    content = content.replace(
-        Regex("""(<key>oauthRedirectURI</key>\s*<string>)[^<]*(</string>)"""),
-        "$1${appConfig.redirectUri}$2"
-    )
-    file.writeText(content)
-}
-
-private fun updateJsonBootConfig(file: File, appConfig: AppConfig) {
-    var content = file.readText()
-    content = content.replace(
-        Regex(""""remoteAccessConsumerKey"\s*:\s*"[^"]*""""),
-        """"remoteAccessConsumerKey": "${appConfig.consumerKey}""""
-    )
-    content = content.replace(
-        Regex(""""oauthRedirectURI"\s*:\s*"[^"]*""""),
-        """"oauthRedirectURI": "${appConfig.redirectUri}""""
-    )
-    file.writeText(content)
 }
 
 private fun signReleaseApk(apkPath: String) {

--- a/TestOrchestrator/src/main/kotlin/AppCompiler.kt
+++ b/TestOrchestrator/src/main/kotlin/AppCompiler.kt
@@ -38,10 +38,6 @@ fun compileApp(
 ) {
     val configuration = if (debug) "Debug" else "Release"
 
-    // OAuth config (consumer key, redirect URI, login server) is now injected at
-    // generation time via test_force.js --consumerkey/--callbackurl/--loginserver
-    // (see AppGenerator.generateApp), so there is nothing to patch here anymore.
-
     with(appInfo) {
         progressBanner?.update {
             context = context.advance("Compile App")

--- a/TestOrchestrator/src/main/kotlin/AppGenerator.kt
+++ b/TestOrchestrator/src/main/kotlin/AppGenerator.kt
@@ -51,6 +51,7 @@ fun generateApp(
     packagerDir: String = "SalesforceMobileSDK-Package",
     packagerVersion: String? = null,
     org: String = FORCE_DOT_COM_ORG,
+    appConfig: KnownAppConfig = KnownAppConfig.ECA_OPAQUE,
 ): AppInfo {
     val generationCommand = mutableListOf(
         "./$packagerDir/test/test_force.js",
@@ -106,9 +107,9 @@ fun generateApp(
     // "ui_test_config.json file not found." if the config is missing at
     // generation time (previously it was only read later, at compile time).
     val testConfig = if (appSource.os == OS.ANDROID) androidTestConfig else iosTestConfig
-    val appConfig = testConfig.getApp(KnownAppConfig.ECA_OPAQUE)
-    generationCommand.add("--consumerkey=${appConfig.consumerKey}")
-    generationCommand.add("--callbackurl=${appConfig.redirectUri}")
+    val resolvedAppConfig = testConfig.getApp(appConfig)
+    generationCommand.add("--consumerkey=${resolvedAppConfig.consumerKey}")
+    generationCommand.add("--callbackurl=${resolvedAppConfig.redirectUri}")
     generationCommand.add("--loginserver=${testConfig.loginHosts.first().url}")
 
     if (generationCommand.runCommand() != 0) {

--- a/TestOrchestrator/src/main/kotlin/AppGenerator.kt
+++ b/TestOrchestrator/src/main/kotlin/AppGenerator.kt
@@ -103,9 +103,10 @@ fun generateApp(
     // callback-URL parser) writes real consumer key / redirect URI / login server
     // into bootconfig, servers.xml, Info.plist and the Android redirect
     // <intent-filter>. Note: the platform UITestConfig is read from
-    // ui_test_config.json lazily, so this line can throw
-    // "ui_test_config.json file not found." if the config is missing at
-    // generation time (previously it was only read later, at compile time).
+    // ui_test_config.json lazily, so this line can throw a "config not found"
+    // error (naming the searched paths and the .sample to copy) if the config
+    // is missing at generation time (previously it was only read later, at
+    // compile time).
     val testConfig = if (appSource.os == OS.ANDROID) androidTestConfig else iosTestConfig
     val resolvedAppConfig = testConfig.getApp(appConfig)
     generationCommand.add("--consumerkey=${resolvedAppConfig.consumerKey}")

--- a/TestOrchestrator/src/main/kotlin/AppGenerator.kt
+++ b/TestOrchestrator/src/main/kotlin/AppGenerator.kt
@@ -98,6 +98,19 @@ fun generateApp(
         generationCommand.add("--use-sfdx")
     }
 
+    // Inject OAuth config at generation time so the template (and the packager's
+    // callback-URL parser) writes real consumer key / redirect URI / login server
+    // into bootconfig, servers.xml, Info.plist and the Android redirect
+    // <intent-filter>. Note: the platform UITestConfig is read from
+    // ui_test_config.json lazily, so this line can throw
+    // "ui_test_config.json file not found." if the config is missing at
+    // generation time (previously it was only read later, at compile time).
+    val testConfig = if (appSource.os == OS.ANDROID) androidTestConfig else iosTestConfig
+    val appConfig = testConfig.getApp(KnownAppConfig.ECA_OPAQUE)
+    generationCommand.add("--consumerkey=${appConfig.consumerKey}")
+    generationCommand.add("--callbackurl=${appConfig.redirectUri}")
+    generationCommand.add("--loginserver=${testConfig.loginHosts.first().url}")
+
     if (generationCommand.runCommand() != 0) {
         throw Exception("Unable to generate app.")
     }

--- a/TestOrchestrator/src/main/kotlin/AppInfo.kt
+++ b/TestOrchestrator/src/main/kotlin/AppInfo.kt
@@ -46,6 +46,12 @@ data class AppInfo(
         isReact -> "$appPath/ios"
         else -> appPath
     }
+    // Name of the Xcode project/workspace, scheme, and built `.app` product. Native and React Native
+    // templates name these after the app (`$appName`). Cordova (hybrid) always emits `App`
+    // (App.xcworkspace, scheme `App`, App.app) regardless of the app name, so the compile and install
+    // steps must target `App` there. The bundle id (`packageName`) is unaffected — Cordova sets it
+    // from config.xml to `com.salesforce.$appName`, matching how the app is installed/launched.
+    val iosXcodeName = if (isHybrid) "App" else appName
     val apkPath = "$androidRoot/app/build/outputs/apk/${
         if (debugBuild) {
             "debug/app-debug.apk"

--- a/TestOrchestrator/src/main/kotlin/AppInstaller.kt
+++ b/TestOrchestrator/src/main/kotlin/AppInstaller.kt
@@ -225,6 +225,10 @@ fun installIosApp(appInfo: AppInfo, sim: SimulatorInfo) {
     val configuration = if (appInfo.debugBuild) "Debug" else "Release"
 
     verbosePrinter?.invoke("Installing App on iOS ${sim.iOSVersion}")
+    // The built `.app` product carries the Xcode PRODUCT_NAME. For Cordova (hybrid) this comes from
+    // config.xml's <name> (the app name), so the product is `$appName.app` even though the Cordova
+    // project/scheme are named `App`. Native/React Native also use `$appName`. So install by
+    // `$appName` in all cases; the app is launched by its bundle id (appInfo.packageName).
     val simInstallResult = "xcrun simctl install ${sim.simId} $buildPath/Products/$configuration-iphonesimulator/${appInfo.appName}.app".runCommand()
     if (simInstallResult != 0) {
         throw Exception("Failed to install ${appInfo.appName} on iOS ${sim.iOSVersion} simulator (exit $simInstallResult).")

--- a/TestOrchestrator/src/main/kotlin/AppUpgrader.kt
+++ b/TestOrchestrator/src/main/kotlin/AppUpgrader.kt
@@ -18,7 +18,12 @@ import kotlin.collections.iterator
  * re-compile it, install it over the old version, and run the upgrade test
  * which asserts the user is still logged in.
  */
-fun performUpgrade(appSource: AppSource, useSF: Boolean, debug: Boolean) {
+fun performUpgrade(
+    appSource: AppSource,
+    useSF: Boolean,
+    debug: Boolean,
+    appConfig: KnownAppConfig = KnownAppConfig.ECA_OPAQUE,
+) {
     // Stop any lingering Gradle daemons from Phase 1 to reclaim memory
     // before Phase 2 compilation starts alongside the running emulator.
     if (appSource.os == OS.ANDROID) {
@@ -32,7 +37,7 @@ fun performUpgrade(appSource: AppSource, useSF: Boolean, debug: Boolean) {
     }
     verbosePrinter?.invoke("Re-generating app with dev SDK")
 
-    val newAppInfo = generateApp(appSource, useSF)
+    val newAppInfo = generateApp(appSource, useSF, appConfig = appConfig)
     compileApp(newAppInfo, debug)
 
     val simulators = if (appSource.os == OS.IOS) getRunningTestSimulators() else emptyList()

--- a/TestOrchestrator/src/main/kotlin/Main.kt
+++ b/TestOrchestrator/src/main/kotlin/Main.kt
@@ -230,9 +230,9 @@ class TestOrchestrator : CliktCommand() {
                     OS.ANDROID -> "Testing ${appSource.appName}"
                 }
                 var totalSteps: Long = when(os) {
-                    OS.ANDROID -> if (reRunTest) 3 else 7
+                    OS.ANDROID -> if (reRunTest) 3 else 5
                     OS.IOS -> {
-                        val base = if (reRunTest) 2 else 5
+                        val base = if (reRunTest) 2 else 3
                         // Add steps per iOS version being tested
                         base + (3L * effectiveVersions.size)
                     }
@@ -245,11 +245,12 @@ class TestOrchestrator : CliktCommand() {
                 }
                 if (upgradeFrom != null) {
                     // Upgrade adds: clone old packager (Phase 1), plus Phase 2:
-                    // re-generate, set login URL, set OAuth, compile, sign (Android only),
+                    // re-generate, compile, sign (Android only),
                     // install upgrade, run upgrade test, pass
+                    // (OAuth/login config is now applied at generation time, not compile time.)
                     totalSteps += when(os) {
-                        OS.ANDROID -> 8L
-                        OS.IOS -> 6L + effectiveVersions.size
+                        OS.ANDROID -> 6L
+                        OS.IOS -> 4L + effectiveVersions.size
                     }
                     if (appSource.isComplexHybrid) totalSteps++
                     if (appSource.isReact) totalSteps++

--- a/TestOrchestrator/src/main/kotlin/Main.kt
+++ b/TestOrchestrator/src/main/kotlin/Main.kt
@@ -36,6 +36,7 @@ import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.arguments.help
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.arguments.unique
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.defaultLazy
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.help
@@ -145,6 +146,13 @@ class TestOrchestrator : CliktCommand() {
     val templateBranch: String? by option("-b", "--templateBranch")
         .help("Generate the app (to test) using a specific branch.  The dev packager is used. " +
                 "\u0085Optionally specify a fork org with '/' (e.g. 'brandonpage/my-feature-branch').")
+    val appConfig: KnownAppConfig by option("--appConfig")
+        .enum<KnownAppConfig>(ignoreCase = true)
+        .default(KnownAppConfig.ECA_OPAQUE)
+        .help("Which OAuth app config (consumer key + redirect URI) from ui_test_config.json to " +
+                "generate the app with. Defaults to ${KnownAppConfig.ECA_OPAQUE.name.lowercase()}. " +
+                "\u0085Use ${KnownAppConfig.ECA_OPAQUE_HOSTLESS.name.lowercase()} to exercise the " +
+                "hostless (scheme:///path) redirect intent-filter delivery path.")
     val useFirebase: Boolean by option("-f", "--firebase").boolean()
         .defaultLazy { IS_CI && upgradeFrom.isNullOrBlank() }
         .help("Run Android tests in Firebase Test Lab. Defaults to on for CI and off otherwise.")
@@ -329,6 +337,7 @@ class TestOrchestrator : CliktCommand() {
                             packagerDir = oldPackager,
                             packagerVersion = templateBranch ?: upgradeFrom,
                             org = templateOrg,
+                            appConfig = appConfig,
                         )
                         relocateApp(oldAppInfo, upgradeFrom!!)
                     } else if (sdkVersion != null) {
@@ -341,6 +350,7 @@ class TestOrchestrator : CliktCommand() {
                             packagerDir = packager,
                             packagerVersion = templateBranch ?: sdkBranch,
                             org = templateOrg,
+                            appConfig = appConfig,
                         )
                     } else if (templateBranch != null) {
                         // Template-only test: Use dev packager
@@ -349,9 +359,10 @@ class TestOrchestrator : CliktCommand() {
                             useSF,
                             packagerVersion = templateBranch,
                             org = templateOrg,
+                            appConfig = appConfig,
                         )
                     } else {
-                        generateApp(appSource, useSF)
+                        generateApp(appSource, useSF, appConfig = appConfig)
                     }
                 } else {
                     verbosePrinter?.invoke("Skipping App Generation")
@@ -380,7 +391,7 @@ class TestOrchestrator : CliktCommand() {
 
                 // Upgrade Phase 2: Upgrade test
                 if (upgradeFrom != null) {
-                    performUpgrade(appSource, useSF, debug)
+                    performUpgrade(appSource, useSF, debug, appConfig = appConfig)
                 }
             } catch (e: Exception) {
                 failures.add(appSource.appName to e)

--- a/iOS/PageObjects/LoginPageObjects/LoginPageObject.swift
+++ b/iOS/PageObjects/LoginPageObjects/LoginPageObject.swift
@@ -139,10 +139,10 @@ class LoginPageObject {
         let topBar = app.otherElements["TopBrowserBar"]
         var closeButton = topBar.buttons["Close"]
         if !closeButton.waitForExistence(timeout: timeout) {
-            // Earlier iOS versions use "Cancel"
+            // Earlier iOS versions use "Cancel"; only that fallback needs its own wait.
             closeButton = topBar.buttons["Cancel"]
+            _ = closeButton.waitForExistence(timeout: timeout)
         }
-        _ = closeButton.waitForExistence(timeout: timeout)
         closeButton.tap()
     }
     

--- a/iOS/PageObjects/LoginPageObjects/LoginPageObject.swift
+++ b/iOS/PageObjects/LoginPageObjects/LoginPageObject.swift
@@ -37,43 +37,113 @@ import XCTest
 class LoginPageObject {
     let app:XCUIApplication
     let timeout:double_t = 10
-    
+
     init(testApp: XCUIApplication) {
         app = testApp
     }
-    
-    func setUsername(name: String) -> Void {
-        sleep(3)
-        hideKeyboard()
-        let nameField = app.descendants(matching: .textField).element
-        _ = nameField.waitForExistence(timeout: timeout * 12)
-        nameField.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
-        sleep(1)
-        nameField.typeText(name)
+
+    /// The browser web content that hosts the login form. Under forced advanced auth the form is
+    /// served in an external browser (ASWebAuthenticationSession). Some app types (notably hybrid)
+    /// trigger authentication more than once on cold launch, which stacks multiple browser sheets —
+    /// each an identical `webViews.webViews.webViews` subtree with its own username/password fields.
+    /// A bare `app.descendants(...).element` then throws "Multiple matching elements found" because
+    /// `.element` requires exactly one match. Drive the frontmost (last-presented, top-of-stack)
+    /// browser — the one the user would actually interact with — and scope every field/button query
+    /// to that single subtree so username, password, and the Log In button all come from it.
+    private var loginWebView: XCUIElement {
+        let webViews = app.webViews.webViews.webViews
+        let count = webViews.count
+        return count > 1 ? webViews.element(boundBy: count - 1) : webViews.firstMatch
     }
-    
+
+    func setUsername(name: String) -> Void {
+        // Under forced advanced auth the login form is served in the external browser
+        // (ASWebAuthenticationSession); wait for it to finish rendering before touching fields.
+        waitForLoginFormReady()
+        hideKeyboard()
+        let nameField = loginWebView.textFields.firstMatch
+        _ = nameField.waitForExistence(timeout: timeout * 12)
+        // The browser pre-populates the username from the OAuth login_hint. A pre-filled web field
+        // does not reliably attach the software keyboard on tap, so typing into it fails with
+        // "Neither element nor any descendant has keyboard focus". When the field already holds a
+        // value, trust the prefill and skip typing — the caller will advance with the "Log In"
+        // button. Only type when the field is genuinely empty.
+        let existing = nameField.value as? String ?? ""
+        if !existing.isEmpty && existing != "Username" {
+            return
+        }
+        setFieldValue(nameField, value: name)
+    }
+
     func setPassword(password: String) -> Void {
         hideKeyboard()
-        let passwordField = app.descendants(matching: .secureTextField).element
-        _ = passwordField.waitForExistence(timeout: timeout)
-        passwordField.tap()
-        sleep(1)
-        passwordField.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
-        sleep(1)
-        passwordField.typeText(password)
+        // Tapping "Log In" on the username step navigates the browser to the password page; allow the
+        // same generous browser-page-load window used for the initial form before touching the field.
+        let passwordField = loginWebView.secureTextFields.firstMatch
+        _ = passwordField.waitForExistence(timeout: timeout * 12)
+        setFieldValue(passwordField, value: password)
     }
-    
+
+    /// Enters `value` into a browser login-form field. The external browser may pre-populate a
+    /// field (e.g. a remembered username), and tapping an already-filled web field does not always
+    /// attach the software keyboard — typing then fails with "no keyboard focus". So tap to focus,
+    /// skip typing when the field already holds the desired value, and only type otherwise. Mirrors
+    /// the SDK AuthFlowTester UITests' setTextField for the forced-advanced-auth browser flow.
+    private func setFieldValue(_ field: XCUIElement, value: String) {
+        field.tap()
+        sleep(1)
+        if (field.value as? String) == value {
+            return
+        }
+        field.typeText(value)
+    }
+
+    /// Waits for the login form served in the external browser (ASWebAuthenticationSession) to be
+    /// fully loaded and interactive. Under forced advanced authentication interactive login happens
+    /// in the browser rather than the in-app WebView; after the browser launches it navigates to the
+    /// login page and the form fields are not immediately available. Waits for the username text
+    /// field inside the web content to appear, which signals the login form has finished rendering.
+    func waitForLoginFormReady() -> Void {
+        // Wait against the whole browser-webview hierarchy (not `loginWebView`) so this resolves before
+        // any stacked sheets settle; once a text field exists, `loginWebView` selects the frontmost one.
+        let webViewTextField = app.webViews.webViews.webViews.textFields.firstMatch
+        _ = webViewTextField.waitForExistence(timeout: timeout * 12)
+    }
+
+    /// Submits the current login step. Under forced advanced authentication the login form is served
+    /// in the external browser (ASWebAuthenticationSession), which renders an on-page "Log In" button.
+    /// Tapping that button is how a user advances, and it does not require keyboard focus — synthesizing
+    /// a Return keypress into a web field fails ("Neither element nor any descendant has keyboard
+    /// focus") whenever the field was pre-filled and never attached the software keyboard. Falls back
+    /// to a Return keypress only if no button is present. Callers drive the form the same way a user
+    /// would: (accept prefilled or type) username, submit; type password, submit.
     func tapLogin() -> Void {
         hideKeyboard()
-        let loginButton = app.webViews.buttons["Log In"].firstMatch
-        _ = loginButton.waitForExistence(timeout: timeout * 6)
-        loginButton.tap()
+        let webView = loginWebView
+        // Salesforce's identity-first browser form labels the button "Log In"; match loosely to also
+        // catch "Log In to Sandbox" and locale/label variants.
+        let loginButton = webView.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'Log In'")).firstMatch
+        if loginButton.waitForExistence(timeout: timeout) && loginButton.isHittable {
+            loginButton.tap()
+            return
+        }
+        // Fallback: submit the on-screen field with Return (only works if the keyboard is attached).
+        let secureField = webView.secureTextFields.firstMatch
+        let field = secureField.exists ? secureField : webView.textFields.firstMatch
+        field.typeText(XCUIKeyboardKey.return.rawValue)
     }
-    
+
+    /// Dismisses the external browser (ASWebAuthenticationSession) without completing login. The
+    /// browser chrome exposes a "Close" button on current iOS versions and "Cancel" on earlier ones.
     func tapBack() -> Void {
-        let backButton = app.navigationBars["Log In"].children(matching: .button).element(boundBy: 0)
-        _ = backButton.waitForExistence(timeout: timeout)
-        backButton.tap()
+        let topBar = app.otherElements["TopBrowserBar"]
+        var closeButton = topBar.buttons["Close"]
+        if !closeButton.waitForExistence(timeout: timeout) {
+            // Earlier iOS versions use "Cancel"
+            closeButton = topBar.buttons["Cancel"]
+        }
+        _ = closeButton.waitForExistence(timeout: timeout)
+        closeButton.tap()
     }
     
     func hideKeyboard() -> Void {

--- a/iOS/Tests/BaseSDKTest.swift
+++ b/iOS/Tests/BaseSDKTest.swift
@@ -47,6 +47,23 @@ class BaseSDKTest: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+
+        // Advanced authentication is forced on by default, so interactive login now happens in the
+        // external browser (ASWebAuthenticationSession). Launching it raises a system consent alert
+        // ("...Wants to Use...to Sign In"), and the browser may also surface paste confirmations.
+        // Dismiss whichever alert appears so it does not block the automation session.
+        addUIInterruptionMonitor(withDescription: "System Alert") { alert in
+            let dominated = ["Allow", "OK", "Continue", "Allow While Using App",
+                             "Don\u{2019}t Allow", "Allow Paste"]
+            for label in dominated {
+                let button = alert.buttons[label]
+                if button.exists {
+                    button.tap()
+                    return true
+                }
+            }
+            return false
+        }
     }
     
     override func tearDown() {

--- a/iOS/Tests/LoginTest.swift
+++ b/iOS/Tests/LoginTest.swift
@@ -41,6 +41,10 @@ class LoginTest: BaseSDKTest {
         let authPage = AuthorizationPageObject(testApp: app)
         app.launch()
 
+        // Trigger pending system-alert interruption handlers. In CI, the
+        // ASWebAuthenticationSession consent sheet can otherwise block login.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
         loginPage.setUsername(name: username)
         loginPage.tapLogin()
         loginPage.setPassword(password: password)

--- a/iOS/Tests/UpgradeTest.swift
+++ b/iOS/Tests/UpgradeTest.swift
@@ -39,6 +39,16 @@ class UpgradeTest: BaseSDKTest {
     /// asserts the login screen is no longer visible.  Intentionally
     /// skips assertAppLoads so we don't need to maintain assertions
     /// for older template UIs.
+    ///
+    /// This phase runs against the *pre-upgrade* (pre-14.0) app the orchestrator installs, where
+    /// advanced authentication is not forced on, so interactive login still happens in the legacy
+    /// in-app WebView with an on-page "Log In" button. `LoginPageObject` has since been re-pointed
+    /// at the external browser (ASWebAuthenticationSession) that 14.0 uses by default, so its
+    /// `tapLogin()` submits by pressing return rather than tapping the WebView button. To avoid
+    /// breaking this phase, the legacy WebView login is driven inline here instead.
+    // TODO: Once the pre-upgrade version under test also forces advanced authentication (i.e. the
+    // from-version is 14.0+), replace this inline legacy WebView flow with `loginPage.tapLogin()`
+    // (keyboard-return submit) to match the other login page objects.
     func testInitialLogin() {
         let app = TestApplication()
         let loginPage = LoginPageObject(testApp: app)
@@ -46,14 +56,29 @@ class UpgradeTest: BaseSDKTest {
         app.launch()
 
         loginPage.setUsername(name: username)
-        loginPage.tapLogin()
+        tapLegacyWebViewLoginButton(app: app)
         loginPage.setPassword(password: password)
-        loginPage.tapLogin()
+        tapLegacyWebViewLoginButton(app: app)
         authPage.tapAllowIfPresent()
 
-        // Assert login screen is no longer showing
-        let loginField = app.webViews.textFields["Username"]
-        XCTAssertFalse(loginField.waitForExistence(timeout: 5), "Login screen is still showing after login.")
+        // Assert login is complete — the login surface is no longer showing. Match on the login
+        // username field regardless of the surface it is hosted in (the legacy in-app WebView on the
+        // pre-upgrade app, or the external browser used from 14.0 on), so this marker survives a
+        // future move of the from-version onto the browser flow.
+        let webViewLoginField = app.webViews.textFields["Username"]
+        let browserLoginField = app.webViews.webViews.webViews.textFields.firstMatch
+        XCTAssertFalse(webViewLoginField.waitForExistence(timeout: 5), "Login screen is still showing after login.")
+        XCTAssertFalse(browserLoginField.exists, "Login screen is still showing after login.")
+    }
+
+    /// Taps the on-page "Log In" button of the legacy in-app WebView login form. Used only by the
+    /// pre-upgrade (pre-14.0) app in phase 1, which authenticates in the in-app WebView rather than
+    /// the external browser. Mirrors the button-tap `LoginPageObject.tapLogin()` performed before it
+    /// was re-pointed at the browser's keyboard-return submit.
+    private func tapLegacyWebViewLoginButton(app: TestApplication) {
+        let loginButton = app.webViews.buttons["Log In"].firstMatch
+        _ = loginButton.waitForExistence(timeout: timeout)
+        loginButton.tap()
     }
 
     /// Launches the upgraded app and asserts that the main content loads

--- a/iOS/Tests/UpgradeTest.swift
+++ b/iOS/Tests/UpgradeTest.swift
@@ -68,7 +68,7 @@ class UpgradeTest: BaseSDKTest {
         let webViewLoginField = app.webViews.textFields["Username"]
         let browserLoginField = app.webViews.webViews.webViews.textFields.firstMatch
         XCTAssertFalse(webViewLoginField.waitForExistence(timeout: 5), "Login screen is still showing after login.")
-        XCTAssertFalse(browserLoginField.exists, "Login screen is still showing after login.")
+        XCTAssertFalse(browserLoginField.waitForExistence(timeout: 3), "Login screen is still showing after login.")
     }
 
     /// Taps the on-page "Log In" button of the legacy in-app WebView login form. Used only by the

--- a/shared/src/kotlin/com/salesforce/UITestConfig.kt
+++ b/shared/src/kotlin/com/salesforce/UITestConfig.kt
@@ -68,12 +68,18 @@ val iosTestConfig: UITestConfig by lazy { loadConfig("ios") }
 
 private fun loadConfig(platformPath: String): UITestConfig {
     val configFileName = "ui_test_config.json"
-    val jsonString = listOf(
+    val searchPaths = listOf(
         "shared/test/$platformPath/$configFileName",
         "/data/local/tmp/$configFileName",
-    ).firstNotNullOfOrNull { path ->
+    )
+    val jsonString = searchPaths.firstNotNullOfOrNull { path ->
         File(path).takeIf { it.exists() }?.readText()
-    } ?: throw Exception("$configFileName file not found.")
+    } ?: throw Exception(
+        "$configFileName not found in any of: ${searchPaths.joinToString()}. " +
+            "Copy shared/test/$platformPath/$configFileName.sample to " +
+            "shared/test/$platformPath/$configFileName and fill in your OAuth app config " +
+            "(consumer key + redirect URI) before running the tests."
+    )
 
     return Json.decodeFromString(jsonString)
 }

--- a/shared/src/kotlin/com/salesforce/UITestConfig.kt
+++ b/shared/src/kotlin/com/salesforce/UITestConfig.kt
@@ -52,6 +52,10 @@ enum class KnownLoginHostConfig {
 
 enum class KnownAppConfig {
     ECA_OPAQUE,
+    // Genuinely-hostless callback (scheme:///path -> android:host=""). Exercises the
+    // empty-authority redirect intent-filter delivery path (W-23294087). Reuses the
+    // ECA opaque consumer key; only the redirect URI differs (triple-slash form).
+    ECA_OPAQUE_HOSTLESS,
     ECA_JWT,
     BEACON_OPAQUE,
     BEACON_JWT,


### PR DESCRIPTION
## What

Updates the UITest orchestrator and page objects for **Advanced Auth default-ON** (Mobile SDK 14.0), where interactive login moves from an in-app WebView to the system browser (Chrome Custom Tabs on Android, `ASWebAuthenticationSession` on iOS). Also adds an E2E case for the genuinely-hostless callback shape.

This is the UITests piece of the generated-Android-redirect work (W-23294087); the Templates, Package, and CordovaPlugin PRs it validates are already merged.

## Changes

**Drive browser-based login (default-ON):**
- Orchestrator injects OAuth config (consumer key / callback URL / login server, from `ui_test_config` `ECA_OPAQUE`) at **generation time** so the packager's callback-URL parser writes the Android redirect `<intent-filter>` and the app has real OAuth config.
- Android `LoginPageObject`: drives the Chrome Custom Tab flow.
- iOS `LoginPageObject`: selects the frontmost `ASWebAuthenticationSession` sheet (avoids "Multiple matching elements") and handles the identity-first username/password flow; `BaseSDKTest`/`UpgradeTest` updated to match.
- Hybrid iOS: target Cordova's fixed `App` Xcode project/scheme/product (`iosXcodeName`) while keeping the `com.salesforce.$appName` bundle id.

**Hostless (`android:host=""`) redirect E2E case:**
- New `KnownAppConfig.ECA_OPAQUE_HOSTLESS` + `eca_opaque_hostless` app entry (reuses the ECA-opaque consumer key; only the redirect URI differs — `ecaadvancedopaque:///success/done`).
- New orchestrator `--appConfig=<KnownAppConfig>` option (**default `ECA_OPAQUE`, so existing behavior is unchanged**), threaded through all `generateApp`/`performUpgrade` call sites; `AppGenerator` no longer hardcodes the config.
- Nightly `android-hostless-redirect` job (native / hybrid / RN) + an `appConfig` input on the reusable Android workflow, suffixed into results dir / artifact / check names to avoid colliding with the base jobs.

**Cleanup:**
- Removed a stale comment in `compileApp` that referenced OAuth-patching code no longer there.

## Test status

**Android — full matrix E2E-proven** (real Chrome Custom Tab login → app loads), host-bearing `ecaadvancedopaque://success/done`:
- `native_kotlin`, `hybrid_local`, `hybrid_remote`, `react_native` — all pass (Pixel 9 Pro XL emulator; native_kotlin + react_native also on physical Pixel 8 Pro).
- The RN run surfaced and fixed a real manifest-merger theme conflict (LoginActivity `@style/SalesforceSDK`) in the Templates PR.

**iOS — regression matrix run; one flag-level regression found (tracked separately):**
- `native_swift` — PASS (login verified).
- `hybrid_local` / `hybrid_remote` — login succeeds in the browser, then the app crashes on the OAuth callback (nil `sceneId` when login is triggered before a UIScene connects). This is a regression from the advanced-auth flag flip, **not** from this PR or the Android generator work. Filed as **W-23374027** with a proposed SDK fix.
- `react_native` — login browser blocked behind an unhandled push-notification system alert (RN-template push registration + interruption-monitor timing); shares the same pre-scene login trigger.